### PR TITLE
11 new vocab terms + 8 new cards

### DIFF
--- a/src/common/api/fetchComponentDataBeforeRender.js
+++ b/src/common/api/fetchComponentDataBeforeRender.js
@@ -3,7 +3,7 @@
 * It is used to make sure server side rendered pages wait for APIs to resolve before returning res.end()
 */
 
-export function fetchComponentDataBeforeRender(dispatch, components, params) {
+export default function fetchComponentDataBeforeRender(dispatch, components, params) {
   const needs = components.reduce( (prev, current) => {
     return (current.need || [])
       .concat((current.WrappedComponent ? current.WrappedComponent.need : []) || [])

--- a/src/common/api/user.js
+++ b/src/common/api/user.js
@@ -2,7 +2,7 @@ import request from 'axios';
 
 import config from '../../../package.json';
 
-export function getUser(token, callback) {
+export default function getUser(token, callback) {
   if (!token) {
     return callback(false);
   }

--- a/src/common/components/game/Board.js
+++ b/src/common/components/game/Board.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { mapValues } from 'lodash'; // (For some reason, _.mapValues doesn't work here.)
+import { mapValues } from 'lodash';
 
 import HexGrid from '../react-hexgrid/HexGrid';
 import Hex from '../react-hexgrid/Hex';

--- a/src/common/components/game/Board.js
+++ b/src/common/components/game/Board.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { mapValues } from 'lodash';
+import { mapValues } from 'lodash'; // (For some reason, _.mapValues doesn't work here.)
 
 import HexGrid from '../react-hexgrid/HexGrid';
 import Hex from '../react-hexgrid/Hex';

--- a/src/common/components/game/Board.js
+++ b/src/common/components/game/Board.js
@@ -66,7 +66,7 @@ class Board extends Component {
   updateHexColors() {
     let hexColors = {};
 
-    if (this.props.placingRobot) {
+    if (this.props.playingRobot) {
       this.getPlayerPlacementTiles().forEach((hex) => {
         if (this.props.currentTurn == 'blue') {
           if (this.props.bluePieces[hex]) {
@@ -164,7 +164,7 @@ class Board extends Component {
 
     const selectedPiece = this.currentPlayerPieces()[this.props.selectedTile];
 
-    if (this.props.placingRobot) {
+    if (this.props.playingRobot) {
       this.getPlayerPlacementTiles().forEach((placementHex) => {
         if (HexUtils.getID(hex) === HexUtils.getID(placementHex) &&
             !this.props.orangePieces[HexUtils.getID(hex)] &&
@@ -242,7 +242,7 @@ Board.propTypes = {
 
   currentTurn: React.PropTypes.string,
   selectedTile: React.PropTypes.string,
-  placingRobot: React.PropTypes.bool,
+  playingRobot: React.PropTypes.bool,
 
   onSelectTile: React.PropTypes.func,
   onHoverTile: React.PropTypes.func

--- a/src/common/components/game/Hand.js
+++ b/src/common/components/game/Hand.js
@@ -33,9 +33,9 @@ class Hand extends Component {
 
     return (
       <ReactCSSTransitionGroup
-        transitionName="example"
+        transitionName="hand"
         transitionEnterTimeout={500}
-        transitionLeaveTimeout={500}
+        transitionLeave={false}
         style={{
           display: 'flex',
           justifyContent: 'center'

--- a/src/common/containers/Game.js
+++ b/src/common/containers/Game.js
@@ -5,6 +5,7 @@ import Divider from 'material-ui/lib/divider';
 import RaisedButton from 'material-ui/lib/raised-button';
 import { connect } from 'react-redux';
 
+import { TYPE_ROBOT } from '../constants';
 import Board from '../components/game/Board';
 import Chat from '../components/game/Chat';
 import PlayerArea from '../components/game/PlayerArea';
@@ -17,7 +18,7 @@ function mapStateToProps(state) {
   return {
     currentTurn: state.game.currentTurn,
     selectedTile: state.game.selectedTile,
-    placingRobot: state.game.placingRobot,
+    playingRobot: state.game.playingCardType == TYPE_ROBOT,
     status: state.game.status,
     hoveredCard: state.game.hoveredCard,
     winner: state.game.winner,
@@ -170,7 +171,7 @@ class Game extends Component {
               bluePieces={this.props.bluePieces}
               orangePieces={this.props.orangePieces}
               currentTurn={this.props.currentTurn}
-              placingRobot={this.props.placingRobot} />
+              playingRobot={this.props.playingRobot} />
             <RaisedButton
               secondary
               label="End Turn"
@@ -200,7 +201,7 @@ class Game extends Component {
 Game.propTypes = {
   currentTurn: React.PropTypes.string,
   selectedTile: React.PropTypes.string,
-  placingRobot: React.PropTypes.bool,
+  playingRobot: React.PropTypes.bool,
   status: React.PropTypes.object,
   hoveredCard: React.PropTypes.object,
   winner: React.PropTypes.string,

--- a/src/common/containers/Game.js
+++ b/src/common/containers/Game.js
@@ -4,6 +4,7 @@ import Paper from 'material-ui/lib/paper';
 import Divider from 'material-ui/lib/divider';
 import RaisedButton from 'material-ui/lib/raised-button';
 import { connect } from 'react-redux';
+import { isNull } from 'lodash';
 
 import { TYPE_EVENT } from '../constants';
 import Board from '../components/game/Board';
@@ -18,7 +19,7 @@ function mapStateToProps(state) {
   return {
     currentTurn: state.game.currentTurn,
     selectedTile: state.game.selectedTile,
-    playingRobot: !_.isNull(state.game.playingCardType) && state.game.playingCardType !== TYPE_EVENT,
+    playingRobot: !isNull(state.game.playingCardType) && state.game.playingCardType !== TYPE_EVENT,
     status: state.game.status,
     hoveredCard: state.game.hoveredCard,
     winner: state.game.winner,

--- a/src/common/containers/Game.js
+++ b/src/common/containers/Game.js
@@ -5,7 +5,7 @@ import Divider from 'material-ui/lib/divider';
 import RaisedButton from 'material-ui/lib/raised-button';
 import { connect } from 'react-redux';
 
-import { TYPE_ROBOT } from '../constants';
+import { TYPE_EVENT } from '../constants';
 import Board from '../components/game/Board';
 import Chat from '../components/game/Chat';
 import PlayerArea from '../components/game/PlayerArea';
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
   return {
     currentTurn: state.game.currentTurn,
     selectedTile: state.game.selectedTile,
-    playingRobot: state.game.playingCardType == TYPE_ROBOT,
+    playingRobot: state.game.playingCardType !== TYPE_EVENT,
     status: state.game.status,
     hoveredCard: state.game.hoveredCard,
     winner: state.game.winner,

--- a/src/common/containers/Game.js
+++ b/src/common/containers/Game.js
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
   return {
     currentTurn: state.game.currentTurn,
     selectedTile: state.game.selectedTile,
-    playingRobot: state.game.playingCardType && state.game.playingCardType !== TYPE_EVENT,
+    playingRobot: !_.isNull(state.game.playingCardType) && state.game.playingCardType !== TYPE_EVENT,
     status: state.game.status,
     hoveredCard: state.game.hoveredCard,
     winner: state.game.winner,

--- a/src/common/containers/Game.js
+++ b/src/common/containers/Game.js
@@ -18,7 +18,7 @@ function mapStateToProps(state) {
   return {
     currentTurn: state.game.currentTurn,
     selectedTile: state.game.selectedTile,
-    playingRobot: state.game.playingCardType !== TYPE_EVENT,
+    playingRobot: state.game.playingCardType && state.game.playingCardType !== TYPE_EVENT,
     status: state.game.status,
     hoveredCard: state.game.hoveredCard,
     winner: state.game.winner,

--- a/src/common/reducers/handlers/game/board.js
+++ b/src/common/reducers/handlers/game/board.js
@@ -33,6 +33,7 @@ export function moveRobot(state, fromHex, toHex, asPartOfAttack = false) {
   return state;
 }
 
+// TODO refactor to use util.updateOrDeleteObjectAtHex()!
 export function attack(state, source, target) {
   // TODO: All attacks are "melee" for now.
   // In the future, there will be ranged attacks that work differently.

--- a/src/common/reducers/handlers/game/board.js
+++ b/src/common/reducers/handlers/game/board.js
@@ -1,4 +1,4 @@
-import { currentPlayer, opponentPlayer, updateOrDeleteObjectAtHex } from './util';
+import { currentPlayer, opponentPlayer, dealDamageToObjectAtHex } from './util';
 
 export function setHoveredCard(state, card) {
   return _.assign(state, {hoveredCard: card});
@@ -39,13 +39,8 @@ export function attack(state, source, target) {
 
   attacker.hasMoved = true;
 
-  // Apply damage.
-  attacker.stats.health -= (defender.stats.attack || 0);
-  defender.stats.health -= (attacker.stats.attack || 0);
-
-  // Update or remove attacker and defender (this also calculates victory).
-  updateOrDeleteObjectAtHex(state, attacker, source);
-  updateOrDeleteObjectAtHex(state, defender, target);
+  dealDamageToObjectAtHex(state, defender.stats.attack || 0, source);
+  dealDamageToObjectAtHex(state, attacker.stats.attack || 0, target);
 
   // Move attacker to defender's space (if possible).
   if (defender.stats.health <= 0 && attacker.stats.health > 0) {

--- a/src/common/reducers/handlers/game/board.js
+++ b/src/common/reducers/handlers/game/board.js
@@ -5,16 +5,10 @@ export function setHoveredCard(state, card) {
 }
 
 export function setSelectedTile(state, tile) {
+  state.selectedTile = (state.selectedTile == tile) ? null : tile; // Toggle tile selection
   state.players[state.currentTurn].selectedCard = null;
-  state.placingRobot = false;
+  state.playingCardType = null;
   state.status.message = '';
-
-  if (state.selectedTile == tile) {
-    state.selectedTile = null; // Deselect
-  } else {
-    state.selectedTile = tile; // Select
-  }
-
   return state;
 }
 

--- a/src/common/reducers/handlers/game/board.js
+++ b/src/common/reducers/handlers/game/board.js
@@ -47,7 +47,7 @@ export function attack(state, source, target) {
 
   // Apply damage.
   attacker.stats.health -= (defender.stats.attack || 0);
-  defender.stats.health -= attacker.stats.attack;
+  defender.stats.health -= (attacker.stats.attack || 0);
 
   // Update or remove attacker and defender (this also calculates victory).
   updateOrDeleteObjectAtHex(state, attacker, source);

--- a/src/common/reducers/handlers/game/cards.js
+++ b/src/common/reducers/handlers/game/cards.js
@@ -1,4 +1,4 @@
-import { TYPE_EVENT, TYPE_ROBOT } from '../../../constants';
+import { TYPE_EVENT } from '../../../constants';
 
 import { currentPlayer, executeCmd } from './util';
 
@@ -9,32 +9,24 @@ export function setSelectedCard(state, cardIdx) {
   state.selectedTile = null;
 
   if (state.players[state.currentTurn].selectedCard == cardIdx) {
-    // Deselect or play event
+    // Clicked on already selected card => Deselect or play event
     if (selectedCard.type === TYPE_EVENT && selectedCard.cost <= energy.available) {
       return playEvent(state, cardIdx);
     } else {
       state.players[state.currentTurn].selectedCard = null;
-      state.placingRobot = false;
+      state.playingCardType = null;
       state.status.message = '';
     }
   } else {
-    // Select
+    // Clicked on unselected card => Select
     state.players[state.currentTurn].selectedCard = cardIdx;
 
     if (selectedCard.cost <= energy.available) {
-      if (selectedCard.type === TYPE_ROBOT) {
-        state.placingRobot = true;
-        state.playingCard = false;
-        state.status.message = 'Select an available tile to place this robot.';
-        state.status.type = 'text';
-      } else {
-        state.placingRobot = false;
-        state.playingCard = true;
-        state.status.message = 'Click this event again to play it.';
-        state.status.type = 'text';
-      }
+      state.playingCardType = selectedCard.type;
+      state.status.message = (selectedCard.type === TYPE_EVENT) ? 'Click this event again to play it.' : 'Select an available tile to play this card.';
+      state.status.type = 'text';
     } else {
-      state.placingRobot = false;
+      state.playingCardType = null;
       state.status.message = 'You do not have enough energy to play this card.';
       state.status.type = 'error';
     }
@@ -57,7 +49,7 @@ export function placeCard(state, card, tile) {
   player.energy.available -= player.hand[selectedCardIndex].cost;
   player.hand.splice(selectedCardIndex, 1);
 
-  state.placingRobot = false;
+  state.playingCardType = null;
   state.status.message = '';
 
   return state;
@@ -73,7 +65,7 @@ function playEvent(state, cardIdx, command) {
   player.energy.available -= selectedCard.cost;
   player.hand.splice(cardIdx, 1);
 
-  state.playingCard = false;
+  state.playingCardType = null;
   state.status.message = '';
 
   return state;

--- a/src/common/reducers/handlers/game/cards.js
+++ b/src/common/reducers/handlers/game/cards.js
@@ -58,7 +58,11 @@ export function placeCard(state, card, tile) {
 function playEvent(state, cardIdx, command) {
   const selectedCard = state.players[state.currentTurn].hand[cardIdx];
 
-  executeCmd(state, selectedCard.command);
+  if (_.isArray(selectedCard.command)) {
+    selectedCard.command.forEach((cmd) => executeCmd(state, cmd));
+  } else {
+    executeCmd(state, selectedCard.command);
+  }
 
   const player = state.players[state.currentTurn];
   player.selectedCard = null;

--- a/src/common/reducers/handlers/game/turns.js
+++ b/src/common/reducers/handlers/game/turns.js
@@ -19,7 +19,7 @@ export function endTurn(state) {
 
   state.currentTurn = opponentName(state);
   state.selectedTile = null;
-  state.placingRobot = false;
+  state.playingRobot = false;
   state.status.message = '';
 
   return state;

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -1,3 +1,4 @@
+import { TYPE_CORE } from '../../../constants';
 import vocabulary from '../../vocabulary/vocabulary';
 
 export function currentPlayer(state) {
@@ -16,30 +17,27 @@ export function allObjectsOnBoard(state) {
   return Object.assign({}, state.players.blue.robotsOnBoard, state.players.orange.robotsOnBoard);
 }
 
-export function updateOrDeleteObjectAtHex(state, object, hex) {
-  if (state.players.blue.robotsOnBoard[hex]) {
-    if (object.stats.health > 0) {
-      state.players.blue.robotsOnBoard[hex] = object;
-    } else {
-      delete state.players.blue.robotsOnBoard[hex];
+export function dealDamageToObjectAtHex(state, amount, hex) {
+  const object = allObjectsOnBoard(state)[hex];
+  object.stats.health -= amount;
+  return updateOrDeleteObjectAtHex(state, object, hex);
+}
 
-      // Check victory conditions.
-      if (object.card.name === 'Blue Core') {
-        state.winner = 'orange';
-      }
-    }
-  } else if (state.players.orange.robotsOnBoard[hex]) {
-    if (object.stats.health > 0) {
-      state.players.orange.robotsOnBoard[hex] = object;
-    } else {
-      delete state.players.orange.robotsOnBoard[hex];
+function updateOrDeleteObjectAtHex(state, object, hex) {
+  const ownerName = (state.players.blue.robotsOnBoard[hex]) ? 'blue' : 'orange';
 
-      // Check victory conditions.
-      if (object.card.name === 'Orange Core') {
-        state.winner = 'blue';
-      }
+  if (object.stats.health > 0) {
+    state.players[ownerName].robotsOnBoard[hex] = object;
+  } else {
+    delete state.players[ownerName].robotsOnBoard[hex];
+
+    // Check victory conditions.
+    if (object.card.type === TYPE_CORE) {
+      state.winner = (ownerName == 'blue') ? 'orange' : 'blue';
     }
   }
+
+  return state;
 }
 
 /* eslint-disable no-unused-vars */

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -12,6 +12,32 @@ export function opponentName(state) {
   return (state.currentTurn == 'blue') ? 'orange' : 'blue';
 }
 
+export function updateOrDeleteObjectAtHex(state, hex, obj) {
+  if (_.has(state.players.blue.robotsOnBoard), hex) {
+    if (obj.stats.health > 0) {
+      state.players.blue.robotsOnBoard[hex] = obj;
+    } else {
+      delete state.players.blue.robotsOnBoard[hex];
+
+      // Check victory conditions.
+      if (obj.card.name === 'Blue Core') {
+        state.winner = 'orange';
+      }
+    }
+  } else if (_.has(state.players.orange.robotsOnBoard), hex) {
+    if (obj.stats.health > 0) {
+      state.players.orange.robotsOnBoard[hex] = obj;
+    } else {
+      delete state.players.orange.robotsOnBoard[hex];
+
+      // Check victory conditions.
+      if (obj.card.name === 'Orange Core') {
+        state.winner = 'blue';
+      }
+    }
+  }
+}
+
 export function allObjectsOnBoard(state) {
   return Object.assign({}, state.players.blue.robotsOnBoard, state.players.orange.robotsOnBoard);
 }
@@ -23,6 +49,7 @@ export function executeCmd(state, cmd) {
   const conditions = vocabulary.conditions(state);
 
   // Global methods
+  const cardsInHand = vocabulary.cardsInHand(state);
   const objectsInPlay = vocabulary.objectsInPlay(state);
   const objectsMatchingCondition = vocabulary.objectsMatchingCondition(state);
 

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -50,6 +50,7 @@ export function executeCmd(state, cmd) {
   const cardsInHand = vocabulary.cardsInHand(state);
   const objectsInPlay = vocabulary.objectsInPlay(state);
   const objectsMatchingCondition = vocabulary.objectsMatchingCondition(state);
+  const attributeSum = vocabulary.attributeSum(state);
 
   eval(cmd)();
   return state;

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -16,14 +16,17 @@ export function allObjectsOnBoard(state) {
   return Object.assign({}, state.players.blue.robotsOnBoard, state.players.orange.robotsOnBoard);
 }
 
+/* eslint-disable no-unused-vars */
 export function executeCmd(state, cmd) {
-  /* eslint-disable no-unused-vars */
   const actions = vocabulary.actions(state);
   const targets = vocabulary.targets(state);
   const conditions = vocabulary.conditions(state);
+
+  // Global methods
+  const objectsInPlay = vocabulary.objectsInPlay(state);
   const objectsMatchingCondition = vocabulary.objectsMatchingCondition(state);
-  /* eslint-enable no-unused-vars */
 
   eval(cmd)();
   return state;
 }
+/* eslint-enable no-unused-vars */

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -12,34 +12,34 @@ export function opponentName(state) {
   return (state.currentTurn == 'blue') ? 'orange' : 'blue';
 }
 
-export function updateOrDeleteObjectAtHex(state, hex, obj) {
-  if (_.has(state.players.blue.robotsOnBoard), hex) {
-    if (obj.stats.health > 0) {
-      state.players.blue.robotsOnBoard[hex] = obj;
+export function allObjectsOnBoard(state) {
+  return Object.assign({}, state.players.blue.robotsOnBoard, state.players.orange.robotsOnBoard);
+}
+
+export function updateOrDeleteObjectAtHex(state, object, hex) {
+  if (state.players.blue.robotsOnBoard[hex]) {
+    if (object.stats.health > 0) {
+      state.players.blue.robotsOnBoard[hex] = object;
     } else {
       delete state.players.blue.robotsOnBoard[hex];
 
       // Check victory conditions.
-      if (obj.card.name === 'Blue Core') {
+      if (object.card.name === 'Blue Core') {
         state.winner = 'orange';
       }
     }
-  } else if (_.has(state.players.orange.robotsOnBoard), hex) {
-    if (obj.stats.health > 0) {
-      state.players.orange.robotsOnBoard[hex] = obj;
+  } else if (state.players.orange.robotsOnBoard[hex]) {
+    if (object.stats.health > 0) {
+      state.players.orange.robotsOnBoard[hex] = object;
     } else {
       delete state.players.orange.robotsOnBoard[hex];
 
       // Check victory conditions.
-      if (obj.card.name === 'Orange Core') {
+      if (object.card.name === 'Orange Core') {
         state.winner = 'blue';
       }
     }
   }
-}
-
-export function allObjectsOnBoard(state) {
-  return Object.assign({}, state.players.blue.robotsOnBoard, state.players.orange.robotsOnBoard);
 }
 
 /* eslint-disable no-unused-vars */

--- a/src/common/reducers/handlers/game/util.js
+++ b/src/common/reducers/handlers/game/util.js
@@ -51,6 +51,7 @@ export function executeCmd(state, cmd) {
   const objectsInPlay = vocabulary.objectsInPlay(state);
   const objectsMatchingCondition = vocabulary.objectsMatchingCondition(state);
   const attributeSum = vocabulary.attributeSum(state);
+  const count = vocabulary.count(state);
 
   eval(cmd)();
   return state;

--- a/src/common/reducers/vocabulary/actions.js
+++ b/src/common/reducers/vocabulary/actions.js
@@ -8,21 +8,35 @@ export default function actions(state) {
     },
 
     draw: function (players, count) {
-      players.forEach(player =>
-        player.hand = player.hand.concat(player.deck.splice(0, count))
-      );
+      players.forEach(function (player) {
+        player.hand = player.hand.concat(player.deck.splice(0, count));
+      });
     },
 
     modifyAttribute: function (objects, attr, func) {
       objects.forEach(function ([hex, object]) {
-        object.stats = _.assign(object.stats, {[attr]: func(object.stats[attr])});
+        if (attr === 'allattributes') {
+          object.stats = _.mapValues(object.stats, func);
+        } else {
+          object.stats = _.assign(object.stats, {[attr]: func(object.stats[attr])});
+        }
       });
     },
 
     modifyEnergy: function (players, func) {
-      players.forEach(player =>
-        player.energy = _.assign(player.energy, {available: func(player.energy.available)})
-      );
-    }
+      players.forEach(function (player) {
+        player.energy = _.assign(player.energy, {available: func(player.energy.available)});
+      });
+    },
+
+    setAttribute: function (objects, attr, num) {
+      objects.forEach(function ([hex, object]) {
+        if (attr === 'allattributes') {
+          object.stats = _.mapValues(object.stats, () => num);
+        } else {
+          object.stats = _.assign(object.stats, {[attr]: num});
+        }
+      });
+    },
   };
 }

--- a/src/common/reducers/vocabulary/actions.js
+++ b/src/common/reducers/vocabulary/actions.js
@@ -1,5 +1,5 @@
 import { TYPE_CORE } from '../../constants';
-import { updateOrDeleteObjectAtHex } from '../handlers/game/util';
+import { dealDamageToObjectAtHex } from '../handlers/game/util';
 
 export default function actions(state) {
   return {
@@ -11,16 +11,16 @@ export default function actions(state) {
 
     dealDamage: function (objects, amount) {
       objects.forEach(function (target) {
-        let hex, object;
+        let hex;
         if (target.robotsOnBoard) {
           // target is a player, so reassign damage to their core.
-          [[hex, object]] = _.filter(_.toPairs(target.robotsOnBoard), hexObj => hexObj[1].card.type == TYPE_CORE);
+          hex = _.find(_.toPairs(target.robotsOnBoard), hexObj => hexObj[1].card.type == TYPE_CORE)[0];
         } else {
-          [hex, object] = target;
+          // target is a [hex, object] pair.
+          hex = target[0];
         }
 
-        object.stats.health -= amount;
-        updateOrDeleteObjectAtHex(state, object, hex);
+        dealDamageToObjectAtHex(state, amount, hex);
       });
     },
 

--- a/src/common/reducers/vocabulary/actions.js
+++ b/src/common/reducers/vocabulary/actions.js
@@ -1,20 +1,27 @@
 export default function actions(state) {
   return {
+    destroy: function (objects) {
+      objects.forEach(function ([hex, object]) {
+        delete state.players.blue.robotsOnBoard[hex];
+        delete state.players.orange.robotsOnBoard[hex];
+      });
+    },
+
     draw: function (players, count) {
       players.forEach(player =>
         player.hand = player.hand.concat(player.deck.splice(0, count))
       );
     },
 
+    modifyAttribute: function (objects, attr, func) {
+      objects.forEach(function ([hex, object]) {
+        object.stats = _.assign(object.stats, {[attr]: func(object.stats[attr])});
+      });
+    },
+
     modifyEnergy: function (players, func) {
       players.forEach(player =>
         player.energy = _.assign(player.energy, {available: func(player.energy.available)})
-      );
-    },
-
-    modifyAttribute: function (objects, attr, func) {
-      objects.forEach(object =>
-        object.stats = _.assign(object.stats, {[attr]: func(object.stats[attr])})
       );
     }
   };

--- a/src/common/reducers/vocabulary/actions.js
+++ b/src/common/reducers/vocabulary/actions.js
@@ -20,7 +20,7 @@ export default function actions(state) {
         }
 
         object.stats.health -= amount;
-        updateOrDeleteObjectAtHex(state, hex, object);
+        updateOrDeleteObjectAtHex(state, object, hex);
       });
     },
 

--- a/src/common/reducers/vocabulary/actions.js
+++ b/src/common/reducers/vocabulary/actions.js
@@ -1,11 +1,17 @@
 export default function actions(state) {
   return {
+    // TODO canMoveAgain(objects)
+
+    // TODO dealDamage(objects, amount)
+
     destroy: function (objects) {
       objects.forEach(function ([hex, object]) {
         delete state.players.blue.robotsOnBoard[hex];
         delete state.players.orange.robotsOnBoard[hex];
       });
     },
+
+    // TODO discard(objects) -- requires choice?
 
     draw: function (players, count) {
       players.forEach(function (player) {

--- a/src/common/reducers/vocabulary/collections.js
+++ b/src/common/reducers/vocabulary/collections.js
@@ -1,6 +1,8 @@
 import { stringToType } from '../../constants';
 import { allObjectsOnBoard } from '../handlers/game/util';
 
+// TODO cardsInPlay(players)
+
 export function objectsInPlay(state) {
   return function (objType) {
     return _.pickBy(allObjectsOnBoard(state), (obj, hex) =>

--- a/src/common/reducers/vocabulary/collections.js
+++ b/src/common/reducers/vocabulary/collections.js
@@ -1,6 +1,14 @@
 import { stringToType } from '../../constants';
 import { allObjectsOnBoard } from '../handlers/game/util';
 
+export function objectsInPlay(state) {
+  return function (objType) {
+    return _.pickBy(allObjectsOnBoard(state), (obj, hex) =>
+      obj.card.type == stringToType(objType)
+    );
+  };
+}
+
 export function objectsMatchingCondition(state) {
   return function (objType, condition) {
     return _.pickBy(allObjectsOnBoard(state), (obj, hex) =>

--- a/src/common/reducers/vocabulary/collections.js
+++ b/src/common/reducers/vocabulary/collections.js
@@ -1,7 +1,12 @@
 import { stringToType } from '../../constants';
 import { allObjectsOnBoard } from '../handlers/game/util';
 
-// TODO cardsInPlay(players)
+export function cardsInHand(state) {
+  return function (players) {
+    const player = players[0]; // Player target is always in the form of list, so just unpack it.
+    return player.hand;
+  };
+}
 
 export function objectsInPlay(state) {
   return function (objType) {

--- a/src/common/reducers/vocabulary/conditions.js
+++ b/src/common/reducers/vocabulary/conditions.js
@@ -2,6 +2,10 @@
 
 export default function conditions(state) {
   return {
+    // TODO adjacentTo(objects) -- may be hard without triggers
+
+    // TODO attributeComparison(attr, comp)
+
     controlledBy: function (players) {
       return function (hex, obj) {
         return _.has(players[0].robotsOnBoard, hex);

--- a/src/common/reducers/vocabulary/conditions.js
+++ b/src/common/reducers/vocabulary/conditions.js
@@ -2,13 +2,18 @@
 
 export default function conditions(state) {
   return {
-    // TODO adjacentTo(objects) -- may be hard without triggers
+    // TODO adjacentTo(objects) -- may be difficult to test without triggers?
 
-    // TODO attributeComparison(attr, comp)
+    attributeComparison: function (attr, comp) {
+      return function (hex, obj) {
+        return comp(obj.stats[attr]);
+      };
+    },
 
     controlledBy: function (players) {
+      const player = players[0]; // Player target is always in the form of list, so just unpack it.
       return function (hex, obj) {
-        return _.has(players[0].robotsOnBoard, hex);
+        return _.has(player.robotsOnBoard, hex);
       };
     }
   };

--- a/src/common/reducers/vocabulary/numbers.js
+++ b/src/common/reducers/vocabulary/numbers.js
@@ -3,3 +3,11 @@ export function attributeSum(state) {
     return _.sum(Object.values(collection).map(object => object.stats[attribute]));
   };
 }
+
+// TODO attributeValue - -may be difficult to test without triggers?
+
+export function count(state) {
+  return function (collection) {
+    return _.size(collection);
+  }
+}

--- a/src/common/reducers/vocabulary/numbers.js
+++ b/src/common/reducers/vocabulary/numbers.js
@@ -9,5 +9,5 @@ export function attributeSum(state) {
 export function count(state) {
   return function (collection) {
     return _.size(collection);
-  }
+  };
 }

--- a/src/common/reducers/vocabulary/numbers.js
+++ b/src/common/reducers/vocabulary/numbers.js
@@ -1,0 +1,5 @@
+export function attributeSum(state) {
+  return function (collection, attribute) {
+    return _.sum(Object.values(collection).map(object => object.stats[attribute]));
+  };
+}

--- a/src/common/reducers/vocabulary/targets.js
+++ b/src/common/reducers/vocabulary/targets.js
@@ -1,5 +1,6 @@
 // Targets are all functions that return an array,
-// either of player objects or of robotOnBoard objects.
+// either of player objects
+// or of [hex, object] pairs representing objects on board.
 
 export default function targets(state) {
   return {
@@ -8,7 +9,7 @@ export default function targets(state) {
     },
 
     all: function (collection) {
-      return Object.values(collection);
+      return _.toPairs(collection);
     }
   };
 }

--- a/src/common/reducers/vocabulary/targets.js
+++ b/src/common/reducers/vocabulary/targets.js
@@ -1,5 +1,7 @@
+import { currentPlayer, opponentPlayer } from '../handlers/game/util';
+
 // Targets are all functions that return an array,
-// either of player objects
+// either of player objects, or of card objects,
 // or of [hex, object] pairs representing objects on board.
 
 export default function targets(state) {
@@ -13,11 +15,15 @@ export default function targets(state) {
     // TODO thisRobot() -- requires triggers
 
     self: function () {
-      return [state.players[state.currentTurn]];
+      return [currentPlayer(state)];
+    },
+
+    opponent: function () {
+      return [opponentPlayer(state)];
+    },
+
+    allPlayers: function () {
+      return [currentPlayer(state), opponentPlayer(state)];
     }
-
-    // TODO opponent()
-
-    // TODO allPlayers()
   };
 }

--- a/src/common/reducers/vocabulary/targets.js
+++ b/src/common/reducers/vocabulary/targets.js
@@ -4,12 +4,20 @@
 
 export default function targets(state) {
   return {
-    self: function () {
-      return [state.players[state.currentTurn]];
-    },
-
     all: function (collection) {
       return _.toPairs(collection);
+    },
+
+    // TODO choose(collection) -- requires choice
+
+    // TODO thisRobot() -- requires triggers
+
+    self: function () {
+      return [state.players[state.currentTurn]];
     }
+
+    // TODO opponent()
+
+    // TODO allPlayers()
   };
 }

--- a/src/common/reducers/vocabulary/vocabulary.js
+++ b/src/common/reducers/vocabulary/vocabulary.js
@@ -2,6 +2,7 @@ import actions from './actions';
 import targets from './targets';
 import conditions from './conditions';
 import { cardsInHand, objectsInPlay, objectsMatchingCondition } from './collections';
+import { attributeSum } from './numbers';
 
 const vocabulary = {
   actions: actions,
@@ -11,7 +12,8 @@ const vocabulary = {
   // Global methods
   cardsInHand: cardsInHand,
   objectsInPlay: objectsInPlay,
-  objectsMatchingCondition: objectsMatchingCondition
+  objectsMatchingCondition: objectsMatchingCondition,
+  attributeSum: attributeSum
 };
 
 export default vocabulary;

--- a/src/common/reducers/vocabulary/vocabulary.js
+++ b/src/common/reducers/vocabulary/vocabulary.js
@@ -1,12 +1,15 @@
 import actions from './actions';
 import targets from './targets';
 import conditions from './conditions';
-import { objectsMatchingCondition } from './collections';
+import { objectsInPlay, objectsMatchingCondition } from './collections';
 
 const vocabulary = {
   actions: actions,
   targets: targets,
   conditions: conditions,
+
+  // Global methods
+  objectsInPlay: objectsInPlay,
   objectsMatchingCondition: objectsMatchingCondition
 };
 

--- a/src/common/reducers/vocabulary/vocabulary.js
+++ b/src/common/reducers/vocabulary/vocabulary.js
@@ -2,7 +2,7 @@ import actions from './actions';
 import targets from './targets';
 import conditions from './conditions';
 import { cardsInHand, objectsInPlay, objectsMatchingCondition } from './collections';
-import { attributeSum } from './numbers';
+import { attributeSum, count } from './numbers';
 
 const vocabulary = {
   actions: actions,
@@ -13,7 +13,8 @@ const vocabulary = {
   cardsInHand: cardsInHand,
   objectsInPlay: objectsInPlay,
   objectsMatchingCondition: objectsMatchingCondition,
-  attributeSum: attributeSum
+  attributeSum: attributeSum,
+  count: count
 };
 
 export default vocabulary;

--- a/src/common/reducers/vocabulary/vocabulary.js
+++ b/src/common/reducers/vocabulary/vocabulary.js
@@ -1,7 +1,7 @@
 import actions from './actions';
 import targets from './targets';
 import conditions from './conditions';
-import { objectsInPlay, objectsMatchingCondition } from './collections';
+import { cardsInHand, objectsInPlay, objectsMatchingCondition } from './collections';
 
 const vocabulary = {
   actions: actions,
@@ -9,6 +9,7 @@ const vocabulary = {
   conditions: conditions,
 
   // Global methods
+  cardsInHand: cardsInHand,
   objectsInPlay: objectsInPlay,
   objectsMatchingCondition: objectsMatchingCondition
 };

--- a/src/common/store/cards.js
+++ b/src/common/store/cards.js
@@ -131,9 +131,18 @@ export const incinerateCard = {
   type: TYPE_EVENT
 };
 
+export const wisdomCard = {
+  name: 'Wisdom',
+  text: 'Draw cards equal to the number of robots you control.',
+  command: '(function () { actions["draw"](targets["self"](), count(objectsMatchingCondition("robot", conditions["controlledBy"](targets["self"]())))); })',
+  cost: 3,
+  type: TYPE_EVENT
+};
+
 export const deck = [
   superchargeCard,
   tankBotCard,
+  wisdomCard,
   incinerateCard,
   discountCard,
   missileStrikeCard,

--- a/src/common/store/cards.js
+++ b/src/common/store/cards.js
@@ -82,7 +82,7 @@ export const wrathOfRobotGodCard = {
 
 export const threedomCard = {
   name: 'Threedom',
-  text: 'Set all stats of all creatures in play to 3.',
+  text: 'Set all stats of all robots in play to 3.',
   command: '(function () { actions["setAttribute"](targets["all"](objectsInPlay("robot")), "allattributes", 3); })',
   cost: 3,
   type: TYPE_EVENT
@@ -90,7 +90,7 @@ export const threedomCard = {
 
 export const earthquakeCard = {
   name: 'Earthquake',
-  text: 'Destroy all creatures that have less than 2 speed.',
+  text: 'Destroy all robots that have less than 2 speed.',
   command: '(function () { actions["destroy"](targets["all"](objectsMatchingCondition("robot", conditions["attributeComparison"]("speed", (function (x) { return x < 2; }))))); })',
   cost: 4,
   type: TYPE_EVENT
@@ -106,7 +106,7 @@ export const discountCard = {
 
 export const untapCard = {
   name: 'Untap',
-  text: 'All creatures you control can move again.',
+  text: 'All robots you control can move again.',
   command: '(function () { actions["canMoveAgain"](targets["all"](objectsMatchingCondition("robot", conditions["controlledBy"](targets["self"]())))); })',
   cost: 3,
   type: TYPE_EVENT
@@ -120,8 +120,21 @@ export const missileStrikeCard = {
   type: TYPE_EVENT
 };
 
+export const incinerateCard = {
+  name: 'Incinerate',
+  text: 'Gain energy equal to the total power of robots you control. Destroy all robots you control.',
+  command: [
+    '(function () { actions["modifyEnergy"](targets["self"](), function (x) { return x + attributeSum(objectsMatchingCondition("robot", conditions["controlledBy"](targets["self"]())), "attack"); }); })',
+    '(function () { actions["destroy"](targets["all"](objectsMatchingCondition("robot", conditions["controlledBy"](targets["self"]())))); })'
+  ],
+  cost: 1,
+  type: TYPE_EVENT
+};
+
 export const deck = [
   superchargeCard,
+  tankBotCard,
+  incinerateCard,
   discountCard,
   missileStrikeCard,
   rampageCard,
@@ -129,7 +142,6 @@ export const deck = [
   threedomCard,
   earthquakeCard,
   wrathOfRobotGodCard,
-  tankBotCard,
   tankBotCard,
   tankBotCard
 ];

--- a/src/common/store/cards.js
+++ b/src/common/store/cards.js
@@ -71,3 +71,20 @@ export const rampageCard = {
   cost: 3,
   type: TYPE_EVENT
 };
+
+export const wrathOfRobotGodCard = {
+  name: 'Wrath of Robot God',
+  text: 'Destroy all robots.',
+  command: '(function () { actions["destroy"](targets["all"](objectsInPlay("robot"))); })',
+  cost: 5,
+  type: TYPE_EVENT
+};
+
+export const deck = [
+  superchargeCard,
+  rampageCard,
+  wrathOfRobotGodCard,
+  tankBotCard,
+  tankBotCard,
+  tankBotCard
+];

--- a/src/common/store/cards.js
+++ b/src/common/store/cards.js
@@ -80,9 +80,18 @@ export const wrathOfRobotGodCard = {
   type: TYPE_EVENT
 };
 
+export const threedomCard = {
+  name: 'Threedom',
+  text: 'Set all stats of all creatures in play to 3.',
+  command: '(function () { actions["setAttribute"](targets["all"](objectsInPlay("robot")), "allattributes", 3); })',
+  cost: 3,
+  type: TYPE_EVENT
+};
+
 export const deck = [
   superchargeCard,
   rampageCard,
+  threedomCard,
   wrathOfRobotGodCard,
   tankBotCard,
   tankBotCard,

--- a/src/common/store/cards.js
+++ b/src/common/store/cards.js
@@ -88,10 +88,46 @@ export const threedomCard = {
   type: TYPE_EVENT
 };
 
+export const earthquakeCard = {
+  name: 'Earthquake',
+  text: 'Destroy all creatures that have less than 2 speed.',
+  command: '(function () { actions["destroy"](targets["all"](objectsMatchingCondition("robot", conditions["attributeComparison"]("speed", (function (x) { return x < 2; }))))); })',
+  cost: 4,
+  type: TYPE_EVENT
+};
+
+export const discountCard = {
+  name: 'Discount',
+  text: 'Reduce the cost of all cards in your hand by 1.',
+  command: '(function () { actions["modifyAttribute"](targets["all"](cardsInHand(targets["self"]())), "cost", function (x) { return x - 1; }); })',
+  cost: 2,
+  type: TYPE_EVENT
+};
+
+export const untapCard = {
+  name: 'Untap',
+  text: 'All creatures you control can move again.',
+  command: '(function () { actions["canMoveAgain"](targets["all"](objectsMatchingCondition("robot", conditions["controlledBy"](targets["self"]())))); })',
+  cost: 3,
+  type: TYPE_EVENT
+};
+
+export const missileStrikeCard = {
+  name: 'Missile Strike',
+  text: 'Deal 5 damage to your opponent.',
+  command: '(function () { actions["dealDamage"](targets["opponent"](), 5); })',
+  cost: 5,
+  type: TYPE_EVENT
+};
+
 export const deck = [
   superchargeCard,
+  discountCard,
+  missileStrikeCard,
   rampageCard,
+  untapCard,
   threedomCard,
+  earthquakeCard,
   wrathOfRobotGodCard,
   tankBotCard,
   tankBotCard,

--- a/src/common/store/defaultState.js
+++ b/src/common/store/defaultState.js
@@ -37,8 +37,7 @@ const defaultState = {
   },
   currentTurn: 'orange',
   selectedTile: null,
-  placingRobot: false,
-  playingCard: false,
+  playingCardType: null,
   hoveredCard: null,
   status: {
     message: '',

--- a/src/common/store/defaultState.js
+++ b/src/common/store/defaultState.js
@@ -3,7 +3,6 @@ import * as cards from './cards';
 const defaultState = {
   players: {
     blue: {
-      health: 20,
       energy: {
         available: 1,
         total: 1
@@ -20,7 +19,6 @@ const defaultState = {
       }
     },
     orange: {
-      health: 20,
       energy: {
         available: 1,
         total: 1
@@ -37,7 +35,7 @@ const defaultState = {
       }
     }
   },
-  currentTurn: 'blue',
+  currentTurn: 'orange',
   selectedTile: null,
   placingRobot: false,
   playingCard: false,

--- a/src/common/store/defaultState.js
+++ b/src/common/store/defaultState.js
@@ -10,7 +10,7 @@ const defaultState = {
       },
       hand: [cards.attackBotCard, cards.concentrationCard],
       selectedCard: null,
-      deck: [cards.superchargeCard, cards.rampageCard, cards.tankBotCard, cards.tankBotCard, cards.tankBotCard],
+      deck: cards.deck,
       robotsOnBoard: {
         '-4,0,4': {
           hasMoved: false,
@@ -27,7 +27,7 @@ const defaultState = {
       },
       hand: [cards.attackBotCard, cards.concentrationCard],
       selectedCard: null,
-      deck: [cards.superchargeCard, cards.rampageCard, cards.tankBotCard, cards.tankBotCard, cards.tankBotCard],
+      deck: cards.deck,
       robotsOnBoard: {
         '4,0,-4': {
           hasMoved: false,

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -10,9 +10,9 @@ import { Provider } from 'react-redux';
 import createLocation from 'history/lib/createLocation';
 import Helmet from 'react-helmet';
 
-import { fetchComponentDataBeforeRender } from '../common/api/fetchComponentDataBeforeRender';
+import fetchComponentDataBeforeRender from '../common/api/fetchComponentDataBeforeRender';
 import configureStore from '../common/store/configureStore';
-import { getUser } from '../common/api/user';
+import getUser from '../common/api/user';
 import routes from '../common/routes';
 import packagejson from '../../package.json';
 import webpackConfig from '../../webpack.config';

--- a/styles/index.css
+++ b/styles/index.css
@@ -129,15 +129,16 @@ svg path {
 
 /* Slide In Animation */
 
-.example-enter {
+.hand-enter {
   transform: translate(500%);
 }
 
-.example-enter.example-enter-active {
+.hand-enter.example-enter-active {
   transform: translate(0%);
   transition: transform 500ms ease-in-out;
 }
 
+/*
 .example-leave {
   transform: translate(-500%);
   opacity: 0;
@@ -149,6 +150,7 @@ svg path {
   transition: transform 500ms ease-in-out;
   transition: opacity 500ms ease-in-out;
 }
+*/
 
 .card-viewer-fade-enter {
   opacity: 0;


### PR DESCRIPTION
New terms (11):
- `actions.{canMoveAgain, dealDamage, destroy, setAttribute}` (also reworked `modifyAttribute`)
- `conditions.attributeComparison`
- `target.{opponent, allPlayers}`
- `cardsInHand, objectsInPlay, attributeSum, count`

New event cards that showcase these terms (8): "Wrath of Robot God", "Threedom", "Earthquake", "Discount", "Untap", "Missile Strike", "Incinerate", "Wisdom".

Plus some refactoring + bug fixes.