### PR TITLE
Reworked sprites for events and structures

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "shuffle-array": "^1.0.1",
     "style-loader": "0.18.2",
     "substitute-loader": "^1.0.0",
+    "trianglify": "wordbots/trianglify",
     "url-loader": "^0.5.9",
     "webpack": "2.6.1",
     "whatwg-fetch": "^2.0.3",

--- a/src/common/components/Sprite.js
+++ b/src/common/components/Sprite.js
@@ -14,6 +14,7 @@ export default class Sprite extends PureComponent {
     size: number,
     scale: number,
     spacing: number,
+    palette: string,
     output: string
   };
 
@@ -30,7 +31,7 @@ export default class Sprite extends PureComponent {
 
         // Available properties: seed, pal, colours, size, spacing, zoom,
         // scaler0, scaler1, falloff, probmin, probmax, bias, gain, mirrorh, mirrorv, despeckle, despur
-        pal: 'nes',
+        pal: this.props.palette,
         colours: 5,
         falloff: 'cosine',
         mirrorh: 1,

--- a/src/common/components/card/Card.js
+++ b/src/common/components/card/Card.js
@@ -17,6 +17,7 @@ import CardCostBadge from './CardCostBadge';
 import CardStat from './CardStat';
 import CardBack from './CardBack';
 import Identicon from './Identicon';
+import TriangleArt from './TriangleArt';
 
 export default class Card extends Component {
   static propTypes = {
@@ -196,16 +197,19 @@ export default class Card extends Component {
         </div>
       );
     } else if (this.props.type === TYPE_EVENT) {
-      const [width, height] = [25 * this.props.scale, 42 * this.props.scale];
+      const [width, height] = [134 * this.props.scale, 42 * this.props.scale];
       return (
         <div
           onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
           style={{
             width: width,
-            height: height,
-            margin: `${10 * this.props.scale}px auto 0`
+            height: height
         }}>
-          <Identicon id={this.props.spriteID || this.props.name} width={width} size={4} />
+          <TriangleArt
+            id={this.props.spriteID || this.props.name}
+            width={width}
+            height={height}
+            cellSize={15 * this.props.scale} />
         </div>
       );
     } else {

--- a/src/common/components/card/Card.js
+++ b/src/common/components/card/Card.js
@@ -9,15 +9,12 @@ import { isEqual, noop } from 'lodash';
 
 import { TYPE_ROBOT, TYPE_CORE, TYPE_EVENT, TYPE_STRUCTURE, typeToString } from '../../constants';
 import { compareCertainKeys, inBrowser } from '../../util/common';
-import loadImages from '../react-hexgrid/HexGridImages';
 import Textfit from '../react-textfit/Textfit';
-import Sprite from '../Sprite';
 
-import CardCostBadge from './CardCostBadge';
-import CardStat from './CardStat';
 import CardBack from './CardBack';
-import Identicon from './Identicon';
-import TriangleArt from './TriangleArt';
+import CardCostBadge from './CardCostBadge';
+import CardImage from './CardImage';
+import CardStat from './CardStat';
 
 export default class Card extends Component {
   static propTypes = {
@@ -186,70 +183,6 @@ export default class Card extends Component {
     }
   }
 
-  renderImage() {
-    if (this.props.type === TYPE_CORE) {
-      const [width, height] = [50 * this.props.scale, 52 * this.props.scale];
-      return (
-        <div style={{
-          width: width,
-          height: height,
-          margin: '3px auto 0'
-        }}>
-          <img src={loadImages()[this.props.img]} width={width} height={height} />
-        </div>
-      );
-    } else if (this.props.type === TYPE_EVENT) {
-      if (this.props.spriteV < 2 && this.props.source !== 'builtin') {
-        // Legacy event images.
-        const [width, height] = [25 * this.props.scale, 42 * this.props.scale];
-        return (
-          <div
-            onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
-            style={{
-              width: width,
-              height: height,
-              margin: `${10 * this.props.scale}px auto 0`
-          }}>
-            <Identicon id={this.props.spriteID || this.props.name} width={width} size={4} />
-          </div>
-        );
-      } else {
-        const [width, height] = [140 * this.props.scale - 6, 42 * this.props.scale];
-        return (
-          <div
-            onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
-            style={{
-              width: width,
-              height: height
-          }}>
-            <TriangleArt
-              id={this.props.spriteID || this.props.name}
-              width={width}
-              height={height}
-              cellSize={15 * this.props.scale} />
-          </div>
-        );
-      }
-    } else {
-      return (
-        <div
-          onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
-          style={{
-            width: 48 * this.props.scale,
-            height: 48 * this.props.scale,
-            margin: '2px auto 3px'
-        }}>
-          <Sprite
-            id={this.props.spriteID || this.props.name}
-            palette={this.props.type === TYPE_ROBOT ? 'nes' : 'greys'}
-            size={24}
-            scale={this.props.scale}
-            output="html" />
-        </div>
-      );
-    }
-  }
-
   renderText() {
     if (!inBrowser()) {
       // Textfit won't work without a DOM, so just estimate something reasonable.
@@ -362,7 +295,14 @@ export default class Card extends Component {
 
                 <Divider/>
 
-                {this.renderImage()}
+                <CardImage
+                  type={this.props.type}
+                  spriteID={this.props.spriteID || this.props.name}
+                  spriteV={this.props.spriteV}
+                  img={this.props.img}
+                  source={this.props.source}
+                  scale={this.props.scale}
+                  onSpriteClick={this.props.onSpriteClick} />
 
                 <Divider/>
 

--- a/src/common/components/card/Card.js
+++ b/src/common/components/card/Card.js
@@ -26,6 +26,7 @@ export default class Card extends Component {
     id: string,
     name: string,
     spriteID: string,
+    spriteV: number,
     type: number,
     text: oneOfType([string, array]),
     rawText: string,
@@ -57,6 +58,7 @@ export default class Card extends Component {
   static defaultProps = {
     stats: {},
     parseResults: '',
+    spriteV: 1,
 
     visible: true,
     selected: false,
@@ -197,21 +199,37 @@ export default class Card extends Component {
         </div>
       );
     } else if (this.props.type === TYPE_EVENT) {
-      const [width, height] = [134 * this.props.scale, 42 * this.props.scale];
-      return (
-        <div
-          onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
-          style={{
-            width: width,
-            height: height
-        }}>
-          <TriangleArt
-            id={this.props.spriteID || this.props.name}
-            width={width}
-            height={height}
-            cellSize={15 * this.props.scale} />
-        </div>
-      );
+      if (this.props.spriteV < 2 && this.props.source !== 'builtin') {
+        // Legacy event images.
+        const [width, height] = [25 * this.props.scale, 42 * this.props.scale];
+        return (
+          <div
+            onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
+            style={{
+              width: width,
+              height: height,
+              margin: `${10 * this.props.scale}px auto 0`
+          }}>
+            <Identicon id={this.props.spriteID || this.props.name} width={width} size={4} />
+          </div>
+        );
+      } else {
+        const [width, height] = [140 * this.props.scale - 6, 42 * this.props.scale];
+        return (
+          <div
+            onClick={this.props.onSpriteClick ? this.props.onSpriteClick : noop}
+            style={{
+              width: width,
+              height: height
+          }}>
+            <TriangleArt
+              id={this.props.spriteID || this.props.name}
+              width={width}
+              height={height}
+              cellSize={15 * this.props.scale} />
+          </div>
+        );
+      }
     } else {
       return (
         <div
@@ -221,7 +239,12 @@ export default class Card extends Component {
             height: 48 * this.props.scale,
             margin: '2px auto 3px'
         }}>
-          <Sprite id={this.props.spriteID || this.props.name} size={24} scale={this.props.scale} output="html" />
+          <Sprite
+            id={this.props.spriteID || this.props.name}
+            palette={this.props.type === TYPE_ROBOT ? 'nes' : 'greys'}
+            size={24}
+            scale={this.props.scale}
+            output="html" />
         </div>
       );
     }

--- a/src/common/components/card/CardImage.js
+++ b/src/common/components/card/CardImage.js
@@ -60,7 +60,7 @@ export default class CardImage extends Component {
               id={this.props.spriteID}
               width={width}
               height={height}
-              cellSize={30 * this.props.scale} />
+              cellSize={25 * this.props.scale} />
           </div>
         );
       }

--- a/src/common/components/card/CardImage.js
+++ b/src/common/components/card/CardImage.js
@@ -1,0 +1,86 @@
+import React, { Component } from 'react';
+import { func, number, string } from 'prop-types';
+
+import { TYPE_ROBOT, TYPE_CORE, TYPE_EVENT } from '../../constants';
+import loadImages from '../react-hexgrid/HexGridImages';
+import Sprite from '../Sprite';
+
+import Identicon from './Identicon';
+import TriangleArt from './TriangleArt';
+
+export default class CardImage extends Component {
+  static propTypes = {
+    type: number,
+    spriteID: string,
+    spriteV: number,
+    img: string,
+    source: string,
+    scale: number,
+
+    onSpriteClick: func
+  };
+
+  render() {
+    if (this.props.type === TYPE_CORE) {
+      const [width, height] = [50 * this.props.scale, 52 * this.props.scale];
+      return (
+        <div style={{
+          width: width,
+          height: height,
+          margin: '3px auto 0'
+        }}>
+          <img src={loadImages()[this.props.img]} width={width} height={height} />
+        </div>
+      );
+    } else if (this.props.type === TYPE_EVENT) {
+      if (this.props.spriteV < 2 && this.props.source !== 'builtin') {
+        // Legacy event images.
+        const [width, height] = [25 * this.props.scale, 42 * this.props.scale];
+        return (
+          <div
+            onClick={this.props.onSpriteClick}
+            style={{
+              width: width,
+              height: height,
+              margin: `${10 * this.props.scale}px auto 0`
+          }}>
+            <Identicon id={this.props.spriteID} width={width} size={4} />
+          </div>
+        );
+      } else {
+        const [width, height] = [140 * this.props.scale - 6, 42 * this.props.scale];
+        return (
+          <div
+            onClick={this.props.onSpriteClick}
+            style={{
+              width: width,
+              height: height
+          }}>
+            <TriangleArt
+              id={this.props.spriteID}
+              width={width}
+              height={height}
+              cellSize={15 * this.props.scale} />
+          </div>
+        );
+      }
+    } else {
+      return (
+        <div
+          onClick={this.props.onSpriteClick}
+          style={{
+            width: 48 * this.props.scale,
+            height: 48 * this.props.scale,
+            margin: '2px auto 3px'
+        }}>
+          <Sprite
+            id={this.props.spriteID}
+            palette={this.props.type === TYPE_ROBOT ? 'nes' : 'greys'}
+            size={24}
+            scale={this.props.scale}
+            output="html" />
+        </div>
+      );
+    }
+  }
+}

--- a/src/common/components/card/CardImage.js
+++ b/src/common/components/card/CardImage.js
@@ -48,7 +48,7 @@ export default class CardImage extends Component {
           </div>
         );
       } else {
-        const [width, height] = [140 * this.props.scale - 6, 42 * this.props.scale];
+        const [width, height] = [140 * this.props.scale - 6, 52 * this.props.scale];
         return (
           <div
             onClick={this.props.onSpriteClick}

--- a/src/common/components/card/CardImage.js
+++ b/src/common/components/card/CardImage.js
@@ -60,7 +60,7 @@ export default class CardImage extends Component {
               id={this.props.spriteID}
               width={width}
               height={height}
-              cellSize={15 * this.props.scale} />
+              cellSize={30 * this.props.scale} />
           </div>
         );
       }

--- a/src/common/components/card/CardViewer.js
+++ b/src/common/components/card/CardViewer.js
@@ -34,6 +34,7 @@ export default class CardViewer extends Component {
                 name={this.props.hoveredCard.card.name}
                 type={this.props.hoveredCard.card.type}
                 spriteID={this.props.hoveredCard.card.spriteID}
+                spriteV={this.props.hoveredCard.card.spriteV}
                 text={splitSentences(this.props.hoveredCard.card.text).map(s => Sentence(s, {parsed: true}))}
                 rawText={this.props.hoveredCard.card.text}
                 img={this.props.hoveredCard.card.img}

--- a/src/common/components/card/TriangleArt.js
+++ b/src/common/components/card/TriangleArt.js
@@ -2,6 +2,8 @@ import React, { PureComponent } from 'react';
 import { number, string } from 'prop-types';
 import trianglify from 'trianglify';
 
+import { inBrowser } from '../../util/common';
+
 export default class TriangleArt extends PureComponent {
   static propTypes = {
     id: string,
@@ -21,7 +23,7 @@ export default class TriangleArt extends PureComponent {
 
   render = () => (
     <img
-      src={trianglify(this.opts).png()}
+      src={inBrowser() ? trianglify(this.opts).png() : ''}
       width={this.props.width}
       height={this.props.height}
       style={{imageRendering: 'pixelated'}} />

--- a/src/common/components/card/TriangleArt.js
+++ b/src/common/components/card/TriangleArt.js
@@ -1,0 +1,29 @@
+import React, { PureComponent } from 'react';
+import { number, string } from 'prop-types';
+import trianglify from 'trianglify';
+
+export default class TriangleArt extends PureComponent {
+  static propTypes = {
+    id: string,
+    width: number,
+    height: number,
+    cellSize: number
+  };
+
+  get opts() {
+    return {
+      seed: this.props.id,
+      width: this.props.width,
+      height: this.props.height,
+      cell_size: this.props.cellSize
+    };
+  }
+
+  render = () => (
+    <img
+      src={trianglify(this.opts).png()}
+      width={this.props.width}
+      height={this.props.height}
+      style={{imageRendering: 'pixelated'}} />
+  )
+}

--- a/src/common/components/card/TriangleArt.js
+++ b/src/common/components/card/TriangleArt.js
@@ -12,12 +12,20 @@ export default class TriangleArt extends PureComponent {
     cellSize: number
   };
 
+  // Simple random number seeded by id.
+  get rand() {
+    return (parseInt(this.props.id, 36) % 1000000) / 1000000;
+  }
+
   get opts() {
+    const cellSizeVariance = (0.5 + this.rand * 1.5);  // (between 0.5 and 2)
+
     return {
       seed: this.props.id,
       width: this.props.width,
       height: this.props.height,
-      cell_size: this.props.cellSize
+      cell_size: this.props.cellSize * cellSizeVariance,
+      y_colors: 'random'
     };
   }
 

--- a/src/common/components/cards/CardGrid.js
+++ b/src/common/components/cards/CardGrid.js
@@ -36,6 +36,7 @@ export default class CardGrid extends Component {
           id={card.id}
           name={card.name}
           spriteID={card.spriteID}
+          spriteV={card.spriteV}
           type={card.type}
           text={splitSentences(card.text).map(Sentence)}
           rawText={card.text || ''}

--- a/src/common/components/cards/CardPreview.js
+++ b/src/common/components/cards/CardPreview.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { array, func, number, string } from 'prop-types';
 
+import { SPRITE_VERSION } from '../../constants';
 import { inBrowser } from '../../util/common';
 import Card from '../card/Card';
 import Sentence from '../card/Sentence';
@@ -43,6 +44,7 @@ export default class CardPreview extends Component {
           <Card
             name={this.props.name || '[Unnamed]'}
             spriteID={this.props.spriteID}
+            spriteV={SPRITE_VERSION}
             type={this.props.type}
             img={'char'}
             cost={this.props.energy}

--- a/src/common/components/game/Board.js
+++ b/src/common/components/game/Board.js
@@ -69,8 +69,8 @@ export default class Board extends Component {
   }
 
   get pieceImages() {
-    return mapValues(this.allPieces, piece =>
-      piece.card.img ? {img: piece.card.img} : {sprite: piece.card.spriteID || piece.card.name}
+    return mapValues(this.allPieces, p =>
+      p.card.img ? {img: p.card.img} : {sprite: p.card.spriteID || p.card.name, type: p.card.type}
     );
   }
 

--- a/src/common/components/game/Hand.js
+++ b/src/common/components/game/Hand.js
@@ -71,6 +71,7 @@ export default class Hand extends Component {
             status={this.props.status}
             name={card.name}
             spriteID={card.spriteID}
+            spriteV={card.spriteV}
             type={card.type}
             text={splitSentences(card.text).map(Sentence)}
             rawText={card.text || ''}

--- a/src/common/components/react-hexgrid/HexPattern.js
+++ b/src/common/components/react-hexgrid/HexPattern.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { object, string } from 'prop-types';
 
+import { TYPE_STRUCTURE } from '../../constants';
 import Sprite from '../Sprite';
 
 import HexUtils from './HexUtils';
@@ -30,7 +31,12 @@ export default class HexPattern extends Component {
         <pattern id={`${id}_piece`} height="100%" width="100%"
           patternContentUnits="objectBoundingBox" viewBox="0 0 1 1"
           preserveAspectRatio="xMidYMid">
-          <Sprite id={image.sprite} size={24} spacing={6} output="svg" />
+          <Sprite
+            id={image.sprite}
+            size={24}
+            spacing={6}
+            output="svg"
+            palette={image.type === TYPE_STRUCTURE ? 'greys' : 'nes'} />
         </pattern>
       );
     }
@@ -38,8 +44,8 @@ export default class HexPattern extends Component {
 
   fillPattern() {
     const id = HexUtils.getID(this.props.hex);
-    const fillImage = this.props.fill ? 
-      this.props.images[`${this.props.fill  }_tile`] : 
+    const fillImage = this.props.fill ?
+      this.props.images[`${this.props.fill  }_tile`] :
       this.props.images['floor'];
 
     return (

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,13 +1,19 @@
 import { capitalize, invert } from 'lodash';
 
-export const PARSER_URL = 'http://parser.wordbots.io';  // 'http://localhost:8080';
-
 // Debug flags.
 export const ALWAYS_ENABLE_DEV_TOOLS = true;
 export const LOG_SOCKET_IO = false;
 export const KEEP_DECKS_UNSHUFFLED = false;
 export const DISABLE_TURN_TIMER = false;
 export const DISPLAY_HEX_IDS = false;
+
+export const PARSER_URL = 'http://parser.wordbots.io';  // 'http://localhost:8080';
+export const PARSE_DEBOUNCE_MS = 500;
+
+export const CARD_SCHEMA_VERSION = 1;
+export const SPRITE_VERSION = 2;
+// Sprite changes:
+// * 1->2: trianglify instead of identicons for events
 
 export const MODE_TUTORIAL = 0;
 export const MODE_CUSTOM = 1;

--- a/src/common/reducers/handlers/cards.js
+++ b/src/common/reducers/handlers/cards.js
@@ -1,4 +1,4 @@
-import { TYPE_EVENT, TYPE_ROBOT } from '../../constants';
+import { SPRITE_VERSION, TYPE_EVENT, TYPE_ROBOT } from '../../constants';
 import { id } from '../../util/common';
 import {
   areIdenticalCards, cardsToJson, cardsFromJson, splitSentences,
@@ -101,6 +101,7 @@ function createCardFromProps(props) {
     name: props.name,
     type: props.type,
     spriteID: props.spriteID,
+    spriteV: SPRITE_VERSION,
     text: sentences.map(s => `${s.sentence}. `).join(''),
     cost: props.cost,
     source: 'user',  // In the future, this will specify *which* user created the card.

--- a/src/common/util/cards.js
+++ b/src/common/util/cards.js
@@ -1,6 +1,6 @@
 import {
   capitalize, compact, countBy, debounce, flatMap, fromPairs,
-  isArray, mapValues, omit, pick, reduce, uniqBy
+  isArray, mapValues, pick, reduce, uniqBy
 } from 'lodash';
 
 import { PARSER_URL, TYPE_ROBOT, TYPE_EVENT, TYPE_STRUCTURE, typeToString } from '../constants';
@@ -274,7 +274,7 @@ export function cardsFromJson(json, callback) {
   // with migrating between schema versions.
   JSON.parse(json.replace(/%27/g, '\\"'))
     .map(card =>
-      Object.assign({}, omit(card, ['schema']), {
+      Object.assign({}, card, {
         id: generateId(),
         source: 'user',
         timestamp: Date.now()
@@ -308,7 +308,7 @@ export function loadDecksFromFirebase(state, data) {
 }
 
 export function saveCardsToFirebase(state) {
-  saveUserData('cards', state.cards.filter(c => c.source !== 'builtin'));
+  saveUserData('cards', state.cards.filter(c => c.source !== 'builtin').map(c => ({...c, schema: CARD_SCHEMA_VERSION})));
 }
 
 export function saveDecksToFirebase(state) {

--- a/src/common/util/cards.js
+++ b/src/common/util/cards.js
@@ -1,9 +1,12 @@
 import {
   capitalize, compact, countBy, debounce, flatMap, fromPairs,
-  isArray, mapValues, pick, reduce, uniqBy
+  isArray, mapValues, omit, pick, reduce, uniqBy
 } from 'lodash';
 
-import { PARSER_URL, TYPE_ROBOT, TYPE_EVENT, TYPE_STRUCTURE, typeToString } from '../constants';
+import {
+  CARD_SCHEMA_VERSION, PARSER_URL, PARSE_DEBOUNCE_MS,
+  TYPE_ROBOT, TYPE_EVENT, TYPE_STRUCTURE, typeToString
+} from '../constants';
 import defaultState from '../store/defaultCollectionState';
 
 import { id as generateId, compareCertainKeys } from './common';
@@ -12,9 +15,6 @@ import { saveUserData, indexParsedSentence } from './firebase';
 //
 // 0. Card-related constants (used below).
 //
-
-const CARD_SCHEMA_VERSION = 1;
-const PARSE_DEBOUNCE_MS = 500;
 
 const SYNONYMS = {
   ' 0 ': ' zero ',
@@ -262,7 +262,7 @@ export function contractKeywords(sentence) {
 //
 
 export function cardsToJson(cards) {
-  const exportedFields = ['name', 'type', 'cost', 'spriteID', 'text', 'stats'];
+  const exportedFields = ['name', 'type', 'cost', 'spriteID', 'spriteV', 'text', 'stats'];
   const cardsToExport = cards.map(card =>
     Object.assign({}, pick(card, exportedFields), {schema: CARD_SCHEMA_VERSION})
   );
@@ -274,7 +274,7 @@ export function cardsFromJson(json, callback) {
   // with migrating between schema versions.
   JSON.parse(json.replace(/%27/g, '\\"'))
     .map(card =>
-      Object.assign({}, card, {
+      Object.assign({}, omit(card, ['schema']), {
         id: generateId(),
         source: 'user',
         timestamp: Date.now()
@@ -308,7 +308,7 @@ export function loadDecksFromFirebase(state, data) {
 }
 
 export function saveCardsToFirebase(state) {
-  saveUserData('cards', state.cards.filter(c => c.source !== 'builtin').map(c => ({...c, schema: CARD_SCHEMA_VERSION})));
+  saveUserData('cards', state.cards.filter(c => c.source !== 'builtin'));
 }
 
 export function saveDecksToFirebase(state) {


### PR DESCRIPTION
#283, #364.

* Events now use [trianglify](http://qrohlf.com/trianglify/) rather than identicons as sprites.
* Structures are now greyscale to better differentiate them from robots.

Before:
<img width="507" alt="screen shot 2017-06-23 at 7 24 42 pm" src="https://user-images.githubusercontent.com/415965/27504992-eb7dc7a8-5849-11e7-9655-6dac3c59f8fe.png">

After:
<img width="503" alt="screen shot 2017-06-23 at 7 23 57 pm" src="https://user-images.githubusercontent.com/415965/27504994-efbf6eb6-5849-11e7-9d3d-04fe5bae3436.png">
