### PR TITLE
fixes platform dependent package.json tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-bin
 coverage
 dist
 lib

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Tests",
+            "program": "${workspaceRoot}\\node_modules\\jest\\bin\\jest.js",
+            "args": [
+                "-i"
+            ],
+            "preLaunchTask": "npm: build",
+            "internalConsoleOptions": "openOnSessionStart",
+            "outFiles": [
+                "${workspaceRoot}/dist/**/*"
+            ]
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/bin/clean.js
+++ b/bin/clean.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+
+/**
+ * Recursively deletes a path. Meant to be a portable `rm -rf`
+ * https://stackoverflow.com/a/32197381
+ * 
+ * @param {string} path - directory or file to be deleted
+ */
+const deleteFolderRecursive = function (path) {
+  if (fs.existsSync(path)) {
+    fs.readdirSync(path).forEach((file, index) => {
+      const curPath = `${path}/${file}`;
+      if (fs.lstatSync(curPath).isDirectory()) { // recurse
+        deleteFolderRecursive(curPath);
+      } else { // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+    fs.rmdirSync(path);
+  }
+};
+
+module.exports = deleteFolderRecursive(process.argv[2]); 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "chrome >= 48"
   ],
   "scripts": {
-    "slate": "rm -rf node_modules && npm install",
-    "clean": "rm -rf dist",
+    "slate": "node bin/clean.js node_modules && npm install",
+    "clean": "node bin/clean.js dist",
     "start": "set NODE_ENV=development && node src/server/index.js --colors --profile",
     "start-prod": "set NODE_ENV=production && node src/server/index.js --progress --colors --profile",
     "build": "npm run clean && set NODE_ENV=production && webpack -p --progress --colors --profile",


### PR DESCRIPTION
4d7af71 fixes platform dependent package.json tasks
=============
Both the "clean" and the "slate" targets used platform dependent commands.
This adds an implementation of "rm -rf" in native node, and changes
invocations of "rm -rf" in package.json to invoke that script instead.

a7db38e adds VS Code workspace settings
============
This fixes the tab stop size to 2 spaces which is consistently used throughout the project. This also adds a launch profile debugging the jest test suite in VS Code.