### PR TITLE
Make /play/practice/[deckId] URLs work

### DIFF
--- a/src/common/components/multiplayer/Lobby.js
+++ b/src/common/components/multiplayer/Lobby.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import { arrayOf, func, number, object, string } from 'prop-types';
-import { shuffle } from 'lodash';
 
-import { KEEP_DECKS_UNSHUFFLED } from '../../constants';
-import { instantiateCard, cardsInDeck } from '../../util/cards';
+import { shuffleCardsInDeck } from '../../util/cards';
 
 import DeckPicker from './DeckPicker';
 import GameBrowser from './GameBrowser';
@@ -33,9 +31,12 @@ export default class Lobby extends Component {
   }
 
   get deck() {
-    const deck = this.props.availableDecks[this.props.selectedDeckIdx];
-    const cards = cardsInDeck(deck, this.props.cards).map(instantiateCard);
-    return KEEP_DECKS_UNSHUFFLED ? cards : shuffle(cards);
+    const { availableDecks, cards, selectedDeckIdx } = this.props;
+    const deck = availableDecks[selectedDeckIdx];
+    return {
+      id: deck.id,
+      cards: shuffleCardsInDeck(deck, cards)
+    };
   }
 
   handleSelectMode = (mode) => {
@@ -43,11 +44,11 @@ export default class Lobby extends Component {
   };
 
   handleJoinGame = (gameId, gameName) => {
-    this.props.onJoinGame(gameId, gameName, this.deck);
+    this.props.onJoinGame(gameId, gameName, this.deck.cards);
   };
 
   handleHostGame = (gameName) => {
-    this.props.onHostGame(gameName, this.deck);
+    this.props.onHostGame(gameName, this.deck.cards);
   };
 
   renderLobbyContent(gameMode, socket) {

--- a/src/common/containers/GameArea.js
+++ b/src/common/containers/GameArea.js
@@ -265,9 +265,9 @@ export class GameArea extends Component {
     }, AI_RESPONSE_TIME_MS);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.collection.firebaseLoaded !== this.props.collection.firebaseLoaded) {
-      this.tryToStartGame(nextProps);
+  componentDidUpdate(prevProps) {
+    if (this.props.collection.firebaseLoaded !== prevProps.collection.firebaseLoaded) {
+      this.tryToStartGame();
     }
   }
 
@@ -290,8 +290,8 @@ export class GameArea extends Component {
   urlMatchesGameMode = mode => this.props.location.pathname.startsWith(Play.urlForGameMode(mode));
 
   /* Try to start a game (based on the URL) if it hasn't started yet. */
-  tryToStartGame = (props = this.props) => {
-    const { collection, started, onStartTutorial, history, match } = props;
+  tryToStartGame = () => {
+    const { started, onStartTutorial, history, match } = this.props;
 
     // If the game hasn't started yet, that means that the player got here
     // by messing with the URL (rather than by clicking a button in the lobby).
@@ -302,7 +302,7 @@ export class GameArea extends Component {
       if (this.urlMatchesGameMode('tutorial')) {
         onStartTutorial();
       } else if (this.urlMatchesGameMode('practice')) {
-        this.tryToStartPracticeGame(match.params.deck, collection);
+        this.tryToStartPracticeGame(match.params.deck);
       } else {
         history.push(Play.baseUrl);
       }
@@ -310,9 +310,8 @@ export class GameArea extends Component {
   };
 
   /* Try to start a practice game from the URL, pending Firebase loading. */
-  tryToStartPracticeGame = (deckId, collection) => {
-    const { history, onStartPractice } = this.props;
-    const { cards, decks, firebaseLoaded } = collection;
+  tryToStartPracticeGame = (deckId) => {
+    const { history, onStartPractice, collection: { cards, decks, firebaseLoaded } } = this.props;
 
     // Decks are stored in Firebase, so we have to wait until
     // we receive data from Firebase before we can try to start a practice game.
@@ -329,7 +328,7 @@ export class GameArea extends Component {
     this.setState({ message : firebaseLoaded ? null : 'Connecting...' });
   };
 
-  updateDimensions = (props = this.props) => {
+  updateDimensions = () => {
     const maxBoardHeight = window.innerHeight - 64 - 150;
     const maxBoardWidth = window.innerWidth - 256;
 

--- a/src/common/containers/GameArea.js
+++ b/src/common/containers/GameArea.js
@@ -249,10 +249,10 @@ export class GameArea extends Component {
   getChildContext = () => ({muiTheme: getMuiTheme(baseTheme)})
 
   componentDidMount() {
+    this.tryToStartGame();
+
     this.updateDimensions();
     window.addEventListener('resize', () => { this.updateDimensions(); });
-
-    this.tryToStartGame();
 
     this.interval = setInterval(() => {
       if (this.props.isPractice && !this.props.winner && this.props.currentTurn === 'blue') {

--- a/src/common/containers/GameArea.js
+++ b/src/common/containers/GameArea.js
@@ -288,17 +288,7 @@ export class GameArea extends Component {
   }
 
   tryToStartGame(props = this.props) {
-    const {
-      collection: { cards, decks, firebaseLoaded },
-      started,
-
-      onStartTutorial,
-      onStartPractice,
-
-      history,
-      location: { pathname },
-      match
-    } = props;
+    const { collection, started, onStartTutorial, onStartPractice } = props;
 
     // If the game hasn't started yet, that means that the player got here
     // by messing with the URL (rather than by clicking a button in the lobby).
@@ -306,9 +296,12 @@ export class GameArea extends Component {
     // start the corresponding game mode.
     // Otherwise, just return to the lobby.
     if (!started) {
+      const { history, location: { pathname }, match } = props;
+
       if (pathname.startsWith(Play.urlForGameMode('tutorial'))) {
         onStartTutorial();
       } else if (pathname.startsWith(Play.urlForGameMode('practice'))) {
+        const { cards, decks, firebaseLoaded } = collection;
         // Decks are stored in Firebase, so we have to wait until
         // we receive data from Firebase before we can start a practice game.
         if (firebaseLoaded) {

--- a/src/common/containers/Play.js
+++ b/src/common/containers/Play.js
@@ -123,7 +123,7 @@ export class Play extends Component {
           <Route path={Play.urlForGameMode('tutorial')} component={GameArea} />
           <Route path={`${Play.urlForGameMode('practice')}/:deck`} component={GameArea} />
           <Route path={Play.urlForGameMode('casual')} render={this.renderLobby} />
-          <Route path={Play.baseUrl} render={this.renderLobby} />
+          <Route exact path={Play.baseUrl} render={this.renderLobby} />
           <Redirect to={Play.baseUrl} />
         </Switch>
 

--- a/src/common/containers/Play.js
+++ b/src/common/containers/Play.js
@@ -7,7 +7,6 @@ import { Redirect, Route, Switch, withRouter } from 'react-router';
 import Chat from '../components/multiplayer/Chat';
 import Lobby from '../components/multiplayer/Lobby';
 import * as collectionActions from '../actions/collection';
-import * as gameActions from '../actions/game';
 import * as socketActions from '../actions/socket';
 
 import GameArea from './GameArea';
@@ -40,12 +39,6 @@ export function mapDispatchToProps(dispatch) {
     onSpectateGame: (id) => {
       dispatch(socketActions.spectate(id));
     },
-    onStartPractice: (deck) => {
-      dispatch(gameActions.startPractice(deck));
-    },
-    onStartTutorial: () => {
-      dispatch(gameActions.startTutorial());
-    },
     onSendChatMessage: (msg) => {
       dispatch(socketActions.chat(msg));
     },
@@ -71,14 +64,13 @@ export class Play extends Component {
     onHostGame: func,
     onJoinGame: func,
     onSpectateGame: func,
-    onStartTutorial: func,
-    onStartPractice: func,
     onSendChatMessage: func,
     onSelectDeck: func
   };
 
   static baseUrl = '/play';
-  static urlForGameMode = (mode) => `${Play.baseUrl}/${mode}`;
+  static urlForGameMode = (mode, deck = null) =>
+    deck ? `${Play.baseUrl}/${mode}/${deck.id}` : `${Play.baseUrl}/${mode}`;
 
   componentDidMount() {
     if (!this.props.socket.connected) {
@@ -98,13 +90,7 @@ export class Play extends Component {
   }
 
   selectMode = (mode, deck) => {
-    if (mode === 'tutorial') {
-      this.props.onStartTutorial();
-    } else if (mode === 'practice') {
-      this.props.onStartPractice(deck);
-    }
-
-    this.props.history.push(Play.urlForGameMode(mode));
+    this.props.history.push(Play.urlForGameMode(mode, deck));
   }
 
   renderLobby = () => {
@@ -135,7 +121,7 @@ export class Play extends Component {
 
         <Switch>
           <Route path={Play.urlForGameMode('tutorial')} component={GameArea} />
-          <Route path={Play.urlForGameMode('practice')} component={GameArea} />
+          <Route path={`${Play.urlForGameMode('practice')}/:deck`} component={GameArea} />
           <Route path={Play.urlForGameMode('casual')} render={this.renderLobby} />
           <Route path={Play.baseUrl} render={this.renderLobby} />
           <Redirect to={Play.baseUrl} />

--- a/src/common/reducers/collection.js
+++ b/src/common/reducers/collection.js
@@ -16,7 +16,7 @@ export default function collection(oldState = defaultState, action) {
   } else {
     switch (action.type) {
       case globalActions.FIREBASE_DATA:
-        return c.loadState(state, action.payload.data);
+        return c.loadState({...state, firebaseLoaded: true}, action.payload.data);
 
       case creatorActions.ADD_TO_COLLECTION:
         return c.saveCard(state, action.payload);

--- a/src/common/store/defaultCollectionState.js
+++ b/src/common/store/defaultCollectionState.js
@@ -17,6 +17,7 @@ const defaultState = {
   ],
   deckBeingEdited: null,
   exportedJson: null,
+  firebaseLoaded: false,
   selectedDeckIdx: 0
 };
 

--- a/src/common/util/cards.js
+++ b/src/common/util/cards.js
@@ -1,9 +1,10 @@
 import {
   capitalize, compact, countBy, debounce, flatMap, fromPairs,
-  isArray, mapValues, omit, pick, reduce, uniqBy
+  isArray, mapValues, omit, pick, reduce, shuffle, uniqBy
 } from 'lodash';
 
 import {
+  KEEP_DECKS_UNSHUFFLED,
   CARD_SCHEMA_VERSION, PARSER_URL, PARSE_DEBOUNCE_MS,
   TYPE_ROBOT, TYPE_EVENT, TYPE_STRUCTURE, typeToString,
   SYNONYMS, KEYWORDS, HINTS, KEYWORD_REGEXES, HINT_REGEXES
@@ -24,6 +25,11 @@ export function areIdenticalCards(card1, card2) {
 
 export function cardsInDeck(deck, cards) {
   return compact((deck.cardIds || []).map(id => cards.find(c => c.id === id)));
+}
+
+export function shuffleCardsInDeck(deck, cards) {
+  const unshuffledCards = cardsInDeck(deck, cards).map(instantiateCard);
+  return KEEP_DECKS_UNSHUFFLED ? cards : shuffle(unshuffledCards);
 }
 
 export function instantiateCard(card) {

--- a/test/containers/GameArea.spec.js
+++ b/test/containers/GameArea.spec.js
@@ -139,7 +139,7 @@ describe('GameArea container', () => {
     );
   });
 
-  it('should start practice mode on page load if the URL is /play/practice/[deckId]', () => {
+  describe('should start practice mode on page load if the URL is /play/practice/[deckId]', () => {
     const dispatchedActions = [];
     const state = combineState({...getDefaultState(), started: false});
     const historyParams = {
@@ -152,32 +152,38 @@ describe('GameArea container', () => {
       dispatchedActions.push(action);
     }
 
-    // If collection.firebaseLoaded = false, do nothing.
-    let game = createGameArea(state, dispatch, {...historyParams, collection: {
-      firebaseLoaded: false
-    }});
-    renderElement(game, true);
-    expect(dispatchedActions.length).toEqual(0);
+    it('should do nothing if collection.firebaseLoaded = false', () => {
+      const game = createGameArea(state, dispatch, {...historyParams, collection: {
+        firebaseLoaded: false
+      }});
+      renderElement(game, true);
 
-    // If collection.firebaseLoaded = true but the deck doesn't exist, redirect to /play.
-    game = createGameArea(state, dispatch, {...historyParams, collection: {
-      firebaseLoaded: true,
-      decks: []
-    }});
-    renderElement(game, true);
-    expect(dispatchedActions.pop()).toEqual(
-      { type: 'HISTORY.PUSH', payload: { url: '/play' } }
-    );
+      expect(dispatchedActions.length).toEqual(0);
+    });
 
-    // If collection.firebaseLoaded = true and the deck exists, start a practice game with that deck.
-    game = createGameArea(state, dispatch, {...historyParams, collection: {
-      firebaseLoaded: true,
-      cards: state.collection.cards,
-      decks: [{ id: 'deckId', cardIds: ['builtin/One Bot', 'builtin/Two Bot'] }]
-    }});
-    renderElement(game, true);
-    const action = dispatchedActions.pop();
-    expect(action.type).toEqual(actions.START_PRACTICE);
-    expect(action.payload.deck.map(c => c.name).sort()).toEqual(['One Bot', 'Two Bot']);
+    it('should redirect to /play if collection.firebaseLoaded = true but the deck doesn\'t exist', () => {
+      const game = createGameArea(state, dispatch, {...historyParams, collection: {
+        firebaseLoaded: true,
+        decks: []
+      }});
+      renderElement(game, true);
+
+      expect(dispatchedActions.pop()).toEqual(
+        { type: 'HISTORY.PUSH', payload: { url: '/play' } }
+      );
+    });
+
+    it('should start a practice game if collection.firebaseLoaded = true and the deck exists', () => {
+      const game = createGameArea(state, dispatch, {...historyParams, collection: {
+        firebaseLoaded: true,
+        cards: state.collection.cards,
+        decks: [{ id: 'deckId', cardIds: ['builtin/One Bot', 'builtin/Two Bot'] }]
+      }});
+      renderElement(game, true);
+
+      const action = dispatchedActions.pop();
+      expect(action.type).toEqual(actions.START_PRACTICE);
+      expect(action.payload.deck.map(c => c.name).sort()).toEqual(['One Bot', 'Two Bot']);
+    });
   });
 });

--- a/test/containers/GameArea.spec.js
+++ b/test/containers/GameArea.spec.js
@@ -12,7 +12,6 @@ import HexGrid from '../../src/common/components/hexgrid/HexGrid';
 import HexUtils from '../../src/common/components/hexgrid/HexUtils';
 import * as actions from '../../src/common/actions/game';
 import gameReducer from '../../src/common/reducers/game';
-import * as cards from '../../src/common/store/cards';
 
 describe('GameArea container', () => {
   it('renders the default game state', () => {

--- a/test/reactHelpers.js
+++ b/test/reactHelpers.js
@@ -22,8 +22,8 @@ export function renderElement(elt, deep = false) {
 
 /* eslint-disable react/no-multi-comp */
 
-export function createGameArea(state, dispatch = noop) {
-  return React.createElement(gameArea.GameArea, Object.assign(gameArea.mapStateToProps(state), gameArea.mapDispatchToProps(dispatch)));
+export function createGameArea(state, dispatch = noop, props = {}) {
+  return React.createElement(gameArea.GameArea, {...gameArea.mapStateToProps(state), ...gameArea.mapDispatchToProps(dispatch), ...props});
 }
 
 function createCreator(state, dispatch = noop) {


### PR DESCRIPTION
This is a prerequisite to #568.

`GameArea` unfortunately got a little messy because we need to load data from Firebase before we can get the cards in a deck, but it takes a few seconds to get a response back from Firebase on page load.