### PR TITLE
adds fade animation 

### DIFF
--- a/src/common/components/multiplayer/Chat.js
+++ b/src/common/components/multiplayer/Chat.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 import { arrayOf, bool, func, object, string } from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import Toggle from 'material-ui/Toggle';
@@ -184,11 +185,13 @@ export default class Chat extends Component {
             height: this.state.optionsVisible ? 'calc(100% - 92px - 144px)' : 'calc(100% - 144px)',
             overflowY: 'scroll'
           }}>
-          {
-            this.mergeMessagesById(messages)
-              .filter(this.filterMessage.bind(this))
-              .map((message, idx) => <ChatMessage key={idx} message={message} idx={idx} />)
-          }
+          <TransitionGroup>
+            {
+              this.mergeMessagesById(messages)
+                .filter(this.filterMessage.bind(this))
+                .map(this.renderFadedMessage.bind(this))
+            }
+          </TransitionGroup>
         </div>
 
         <div style={{backgroundColor: '#fff'}}>
@@ -204,6 +207,20 @@ export default class Chat extends Component {
           />
         </div>
       </div>
+    );
+  }
+
+
+  renderFadedMessage(message, idx) {
+    const fadeTimeMs = 500;
+    return (
+      <CSSTransition
+        key={idx}
+        timeout={fadeTimeMs}
+        classNames="chat-message"
+      >
+        <ChatMessage key={idx} message={message} idx={idx} />
+      </CSSTransition>
     );
   }
 

--- a/src/common/components/multiplayer/Chat.js
+++ b/src/common/components/multiplayer/Chat.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { TransitionGroup } from 'react-transition-group';
 import { arrayOf, bool, func, object, string } from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import Toggle from 'material-ui/Toggle';
@@ -74,7 +73,7 @@ export default class Chat extends Component {
             .value();
   }
 
-  filterMessage(message) {
+  filterMessage = (message) => {
     if (message.user === '[Server]') {
       return this.state.showServerMsgs;
     } else if (message.user === '[Game]') {
@@ -185,13 +184,11 @@ export default class Chat extends Component {
             height: this.state.optionsVisible ? 'calc(100% - 92px - 144px)' : 'calc(100% - 144px)',
             overflowY: 'scroll'
           }}>
-          <TransitionGroup>
-            {
-              this.mergeMessagesById(messages)
-                .filter(this.filterMessage.bind(this))
-                .map((message, idx) => <ChatMessage key={idx} message={message} idx={idx} />)
-            }
-          </TransitionGroup>
+          {
+            this.mergeMessagesById(messages)
+              .filter(this.filterMessage)
+              .map((message, idx) => <ChatMessage key={idx} message={message} idx={idx} />)
+          }
         </div>
 
         <div style={{backgroundColor: '#fff'}}>

--- a/src/common/components/multiplayer/Chat.js
+++ b/src/common/components/multiplayer/Chat.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import { TransitionGroup } from 'react-transition-group';
 import { arrayOf, bool, func, object, string } from 'prop-types';
 import Drawer from 'material-ui/Drawer';
 import Toggle from 'material-ui/Toggle';
@@ -189,7 +189,7 @@ export default class Chat extends Component {
             {
               this.mergeMessagesById(messages)
                 .filter(this.filterMessage.bind(this))
-                .map(this.renderFadedMessage.bind(this))
+                .map((message, idx) => <ChatMessage key={idx} message={message} idx={idx} />)
             }
           </TransitionGroup>
         </div>
@@ -207,20 +207,6 @@ export default class Chat extends Component {
           />
         </div>
       </div>
-    );
-  }
-
-
-  renderFadedMessage(message, idx) {
-    const fadeTimeMs = 500;
-    return (
-      <CSSTransition
-        key={idx}
-        timeout={fadeTimeMs}
-        classNames="chat-message"
-      >
-        <ChatMessage key={idx} message={message} idx={idx} />
-      </CSSTransition>
     );
   }
 

--- a/src/common/components/multiplayer/ChatMessage.js
+++ b/src/common/components/multiplayer/ChatMessage.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { object, number } from 'prop-types';
-import { CSSTransition } from 'react-transition-group';
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import CardTooltip from '../card/CardTooltip';
 
@@ -12,26 +12,27 @@ export default class ChatMessage extends Component {
 
   render() {
     const { message, idx } = this.props;
-    const fadeTimeMs = 500;
 
     return (
-      <CSSTransition
-        key={idx}
-        timeout={fadeTimeMs}
-        classNames="chat-message"
-      >
-        <div
-          name="chat-message"
-          key={idx}
-          style={{
-            color: ['[Game]', '[Server]'].includes(message.user) ? '#888' : '#000',
-            marginBottom: 5,
-            wordBreak: 'break-word'
-          }}>
-          <b>{message.user}</b>:&nbsp;
-          {message.text.split('|').map((phrase, phraseIdx) => this.renderPhrase(phrase, message, idx, phraseIdx))}
-        </div>
-      </CSSTransition>
+      <TransitionGroup key={idx}>
+        <CSSTransition
+          appear
+          timeout={1000}
+          classNames="chat-message"
+        >
+          <div
+            name="chat-message"
+            key={idx}
+            style={{
+              color: ['[Game]', '[Server]'].includes(message.user) ? '#888' : '#000',
+              marginBottom: 5,
+              wordBreak: 'break-word'
+            }}>
+            <b>{message.user}</b>:&nbsp;
+            {message.text.split('|').map((phrase, phraseIdx) => this.renderPhrase(phrase, message, idx, phraseIdx))}
+          </div>
+        </CSSTransition>
+      </TransitionGroup>
     );
   }
 

--- a/src/common/components/multiplayer/ChatMessage.js
+++ b/src/common/components/multiplayer/ChatMessage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { object, number } from 'prop-types';
+import { CSSTransition } from 'react-transition-group';
 
 import CardTooltip from '../card/CardTooltip';
 
@@ -11,22 +12,30 @@ export default class ChatMessage extends Component {
 
   render() {
     const { message, idx } = this.props;
-    const renderPhrase = this.renderPhrase.bind(this);
+    const fadeTimeMs = 500;
+
     return (
-      <div
-        name="chat-message"
+      <CSSTransition
         key={idx}
-        style={{
-          color: ['[Game]', '[Server]'].includes(message.user) ? '#888' : '#000',
-          marginBottom: 5,
-          wordBreak: 'break-word'
-        }}>
-        <b>{message.user}</b>: {message.text.split('|').map((phrase, phraseIdx) => renderPhrase(phrase, message, idx, phraseIdx))}
-      </div>
+        timeout={fadeTimeMs}
+        classNames="chat-message"
+      >
+        <div
+          name="chat-message"
+          key={idx}
+          style={{
+            color: ['[Game]', '[Server]'].includes(message.user) ? '#888' : '#000',
+            marginBottom: 5,
+            wordBreak: 'break-word'
+          }}>
+          <b>{message.user}</b>:&nbsp;
+          {message.text.split('|').map((phrase, phraseIdx) => this.renderPhrase(phrase, message, idx, phraseIdx))}
+        </div>
+      </CSSTransition>
     );
   }
 
-  renderPhrase(phrase, message, messageIdx, phraseIdx) {
+  renderPhrase = (phrase, message, messageIdx, phraseIdx) => {
     const card = (message.cards || {})[phrase];
     const key = `${messageIdx}_${phrase}_${phraseIdx}`;
     if (card) {

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -6,6 +6,25 @@
   transition: transform 500ms ease-in-out;
 }
 
+.chat-message-enter {
+  opacity: 0.01;
+}
+
+.chat-message-enter-active {
+  opacity: 1;
+  transition: opacity 1000ms ease-in;
+}
+
+.chat-message-exit {
+  opacity: 1;
+}
+
+.chat-message-exit-active {
+  opacity: 0.01;
+  transition: opacity 800ms ease-in;
+}
+
+
 .hex-piece-enter {
   opacity: 0;
 }

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -6,24 +6,13 @@
   transition: transform 500ms ease-in-out;
 }
 
-.chat-message-enter {
-  opacity: 0.01;
+.chat-message-appear {
+  background-color: #ffc107;
 }
-
-.chat-message-enter-active {
-  opacity: 1;
-  transition: opacity 1000ms ease-in;
+.chat-message-appear-active {
+  background-color: transparent;
+  transition: background-color 500ms ease-in-out;
 }
-
-.chat-message-exit {
-  opacity: 1;
-}
-
-.chat-message-exit-active {
-  opacity: 0.01;
-  transition: opacity 800ms ease-in;
-}
-
 
 .hex-piece-enter {
   opacity: 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8699,16 +8699,16 @@ react-side-effect@^1.1.0:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
 
-react-slick@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.20.0.tgz#43fcdba635eb31f0f88d871ff81fb17d309a2315"
+react-slick@^0.22.2:
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.22.2.tgz#8c2183bf88bb0ab316984e14b85b05e8d446ee27"
   dependencies:
     can-use-dom "^0.1.0"
     classnames "^2.2.5"
     create-react-class "^15.5.2"
     enquire.js "^2.1.6"
     json2mq "^0.2.0"
-    object-assign "^4.1.0"
+    resize-observer-polyfill "^1.5.0"
 
 react-sound@1.1.0:
   version "1.1.0"
@@ -9257,6 +9257,10 @@ requireindex@^1.1.0:
 requires-port@1.0.x, requires-port@1.x.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.0.tgz#660ff1d9712a2382baa2cad450a4716209f9ca69"
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This adds a 500ms fade-in animation to the chat messages. Moving the CSSTransition out of `Chat.js` where it is now onto `ChatMessage.js` seems to break the transition. @jacobnisnevich any idea if this can be done? 

Also you will notice there are no tests. Since this is just a dumb (no business logic) effect that is rendered for every ChatMessage, I don't think the effort to mock out CSSTransitions buys us much in terms of testing.