### PR TITLE
fix(HelpDialog.js): correctly position video tutorial

### DIFF
--- a/src/common/components/cards/HelpDialog.js
+++ b/src/common/components/cards/HelpDialog.js
@@ -30,6 +30,7 @@ export default class HelpDialog extends Component {
       <div className="markdownBlock">
         <h2>Video Tutorial</h2>
         <IFrame
+          position="relative"
           url="https://www.youtube.com/embed/GeZwKIOKc1c?rel=0"
           width="708"
           height="444"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1996162/38473299-cbfdf5ce-3b42-11e8-8b1c-20dc779be4ae.png)
