### PR TITLE
sharedDeck mode support

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -5,7 +5,7 @@ import { capitalize, fromPairs, invert } from 'lodash';
 export const ALWAYS_ENABLE_DEV_TOOLS = true;
 export const LOG_SOCKET_IO = false;
 export const KEEP_DECKS_UNSHUFFLED = false;
-export const DISABLE_TURN_TIMER = true;
+export const DISABLE_TURN_TIMER = false;
 export const DISABLE_AI = false;
 export const DISPLAY_HEX_IDS = false;
 export const ENABLE_REDUX_TIME_TRAVEL = false;

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -14,8 +14,9 @@ const LOCAL_PARSER_PORT = 8080;
 
 /* Game rules. */
 
-export const DEFAULT_GAME_MODE = 'normal';  // 'normal' or 'sharedDeck'
+export const DEFAULT_GAME_MODE = 'normal';  // See store/gameModes
 export const STARTING_PLAYER_HEALTH = 20;
+export const DECK_SIZE = 30;
 export const MAX_HAND_SIZE = 7;
 
 /* Animations. */

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -5,7 +5,7 @@ import { capitalize, fromPairs, invert } from 'lodash';
 export const ALWAYS_ENABLE_DEV_TOOLS = true;
 export const LOG_SOCKET_IO = false;
 export const KEEP_DECKS_UNSHUFFLED = false;
-export const DISABLE_TURN_TIMER = false;
+export const DISABLE_TURN_TIMER = true;
 export const DISABLE_AI = false;
 export const DISPLAY_HEX_IDS = false;
 export const ENABLE_REDUX_TIME_TRAVEL = false;
@@ -14,6 +14,7 @@ const LOCAL_PARSER_PORT = 8080;
 
 /* Game rules. */
 
+export const DEFAULT_GAME_MODE = 'normal';  // 'normal' or 'sharedDeck'
 export const STARTING_PLAYER_HEALTH = 20;
 export const MAX_HAND_SIZE = 7;
 

--- a/src/common/containers/Play.js
+++ b/src/common/containers/Play.js
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { Redirect, Route, Switch, withRouter } from 'react-router';
 
+import { DECK_SIZE } from '../constants';
 import Chat from '../components/multiplayer/Chat';
 import Lobby from '../components/multiplayer/Lobby';
 import * as collectionActions from '../actions/collection';
@@ -12,7 +13,7 @@ import * as socketActions from '../actions/socket';
 import GameAreaContainer from './GameAreaContainer';
 
 export function mapStateToProps(state) {
-  const validDecks = state.collection.decks.filter(d => d.cardIds.length === 30);
+  const validDecks = state.collection.decks.filter(d => d.cardIds.length === DECK_SIZE);
 
   return {
     started: state.game.started,

--- a/src/common/reducers/game.js
+++ b/src/common/reducers/game.js
@@ -1,5 +1,6 @@
 import { cloneDeep, isArray, reduce } from 'lodash';
 
+import { DEFAULT_GAME_MODE } from '../constants';
 import { id } from '../util/common';
 import { triggerSound } from '../util/game';
 import * as actions from '../actions/game';
@@ -22,27 +23,34 @@ export default function game(state = cloneDeep(defaultState), action, allowed = 
   }
 }
 
-export function handleAction(oldState, action) {
+export function handleAction(oldState, { type, payload }) {
   let state = Object.assign({}, oldState);
 
-  if (!PURELY_VISUAL_ACTIONS.includes(action.type)) {
+  if (!PURELY_VISUAL_ACTIONS.includes(type)) {
     state = Object.assign(state, {
       actionId: id()  // actionId is used to correctly merge actions in the action log.
     });
   }
 
-  switch (action.type) {
+  switch (type) {
     case socketActions.GAME_START:
-      return g.newGame(state, action.payload.player || 'orange', action.payload.usernames || {}, action.payload.decks, action.payload.seed);
+      return g.newGame(
+        state,
+        payload.player || 'orange',
+        payload.usernames || {},
+        payload.decks,
+        payload.seed,
+        payload.gameMode || DEFAULT_GAME_MODE  // TODO Actually send the gameMode field from the server.
+      );
 
     case actions.START_TUTORIAL:
       return g.startTutorial(state);
 
     case actions.START_PRACTICE:
-      return g.startPractice(state, action.payload.deck);
+      return g.startPractice(state, payload.deck);
 
     case actions.START_SANDBOX:
-      return g.startSandbox(state, action.payload.card);
+      return g.startSandbox(state, payload.card);
 
     case actions.AI_RESPONSE:
       return g.aiResponse(state);
@@ -51,10 +59,10 @@ export function handleAction(oldState, action) {
       return Object.assign(state, {started: false});
 
     case actions.MOVE_ROBOT:
-      return g.moveRobot(state, action.payload.from, action.payload.to);
+      return g.moveRobot(state, payload.from, payload.to);
 
     case actions.ATTACK:
-      return g.attack(state, action.payload.source, action.payload.target);
+      return g.attack(state, payload.source, payload.target);
 
     case actions.ATTACK_RETRACT:
       return Object.assign(state, {attack: {...state.attack, retract: true}});
@@ -63,27 +71,27 @@ export function handleAction(oldState, action) {
       return g.attackComplete(state);
 
     case actions.ACTIVATE_OBJECT:
-      return g.activateObject(state, action.payload.abilityIdx);
+      return g.activateObject(state, payload.abilityIdx);
 
     case actions.PLACE_CARD:
-      return g.placeCard(state, action.payload.cardIdx, action.payload.tile);
+      return g.placeCard(state, payload.cardIdx, payload.tile);
 
     case actions.PASS_TURN:
-      return g.passTurn(state, action.payload.player);
+      return g.passTurn(state, payload.player);
 
     case actions.SET_SELECTED_CARD:
-      return g.setSelectedCard(state, action.payload.player, action.payload.selectedCard);
+      return g.setSelectedCard(state, payload.player, payload.selectedCard);
 
     case actions.SET_SELECTED_TILE:
-      return g.setSelectedTile(state, action.payload.player, action.payload.selectedTile);
+      return g.setSelectedTile(state, payload.player, payload.selectedTile);
 
     case actions.DESELECT:
-      return g.deselect(state, action.payload.player);
+      return g.deselect(state, payload.player);
 
     case actions.ADD_CARD_TO_TOP_OF_DECK: {
       // Only to be used in sandbox mode.
-      const { player } = action.payload;
-      const card = { ...action.payload.card, id: id() };
+      const { player } = payload;
+      const card = { ...payload.card, id: id() };
       state.players[player].deck.unshift(card);
       return state;
     }
@@ -93,10 +101,10 @@ export function handleAction(oldState, action) {
 
     case socketActions.CURRENT_STATE:
       // This is used for spectating an in-progress game - the server sends back a log of all actions so far.
-      return reduce(action.payload.actions, game, state);
+      return reduce(payload.actions, game, state);
 
     case socketActions.FORFEIT: {
-      state = Object.assign(state, {winner: action.payload.winner});
+      state = Object.assign(state, {winner: payload.winner});
       state = triggerSound(state, state.winner === state.player ? 'win.wav' : 'lose.wav');
       return state;
     }

--- a/src/common/store/defaultGameState.js
+++ b/src/common/store/defaultGameState.js
@@ -58,6 +58,7 @@ const defaultState = {
     blue: bluePlayerState([]),
     orange: orangePlayerState([])
   },
+  gameMode: 'normal',
   started: false,
   tutorial: false,
   practice: false,

--- a/src/common/store/defaultGameState.js
+++ b/src/common/store/defaultGameState.js
@@ -1,6 +1,7 @@
 import { BLUE_CORE_HEX, ORANGE_CORE_HEX } from '../constants';
 
 import * as cards from './cards';
+import { NormalGameMode } from './gameModes';
 
 const STARTING_PLAYER = 'orange';
 
@@ -58,7 +59,7 @@ const defaultState = {
     blue: bluePlayerState([]),
     orange: orangePlayerState([])
   },
-  gameMode: 'normal',
+  gameMode: NormalGameMode.name,
   started: false,
   tutorial: false,
   practice: false,

--- a/src/common/store/gameModes.js
+++ b/src/common/store/gameModes.js
@@ -1,0 +1,67 @@
+import { cloneDeep, shuffle } from 'lodash';
+import seededRNG from 'seed-random';
+
+import { triggerSound } from '../util/game';
+
+import defaultState, { bluePlayerState, orangePlayerState } from './defaultGameState';
+
+export class GameMode {
+  name = undefined;
+
+  static fromString(gameModeStr) {
+    const modes = [ NormalGameMode, SharedDeckGameMode ];
+    const mode = modes.find(m => m.name === gameModeStr);
+    if (!mode) {
+      throw `Unknown game mode: ${gameModeStr}`;
+    }
+    return mode;
+  }
+
+  isActive(state) {
+    return state.gameMode === this.name;
+  }
+
+  startGame(state, player, usernames, decks, seed) {
+    state = Object.assign(state, cloneDeep(defaultState), {
+      gameMode: this.name,
+      player: player,
+      rng: seededRNG(seed),
+      started: true,
+      usernames
+    });
+    state = triggerSound(state, 'yourmove.wav');
+
+    return state;
+  }
+}
+
+export const NormalGameMode = new (class extends GameMode {
+  name = 'normal';
+
+  startGame(state, player, usernames, decks, seed) {
+    state = super.startGame(state, player, usernames, decks, seed);
+
+    state.players.blue = bluePlayerState(decks.blue);
+    state.players.orange = orangePlayerState(decks.orange);
+
+    return state;
+  }
+});
+
+export const SharedDeckGameMode = new (class extends GameMode {
+  name = 'sharedDeck';
+
+  startGame(state, player, usernames, decks, seed) {
+    state = super.startGame(state, player, usernames, decks, seed);
+
+    const deck = shuffle([...decks.blue, ...decks.orange]);
+    // Give blue the top two cards, orange the next two (to form their starting hands),
+    // and both players the rest of the deck.
+    const [topTwo, nextTwo, restOfDeck] = [deck.slice(0, 2), deck.slice(2, 4), deck.slice(4)];
+
+    state.players.blue = bluePlayerState([...topTwo, ...restOfDeck]);
+    state.players.orange = orangePlayerState([...nextTwo, ...restOfDeck]);
+
+    return state;
+  }
+});

--- a/src/common/util/game.js
+++ b/src/common/util/game.js
@@ -273,7 +273,8 @@ export function newGame(state, player, usernames, decks, seed = 0, gameMode = DE
     state.players.orange = orangePlayerState(decks.orange);
   } else if (gameMode === 'sharedDeck') {
     const deck = shuffle([...decks.blue, ...decks.orange]);
-    // Give blue the top two cards, orange the next two, and both players the rest of the deck.
+    // Give blue the top two cards, orange the next two (to form their starting hands),
+    // and both players the rest of the deck.
     const [topTwo, nextTwo, restOfDeck] = [deck.slice(0, 2), deck.slice(2, 4), deck.slice(4)];
     state.players.blue = bluePlayerState([...topTwo, ...restOfDeck]);
     state.players.orange = orangePlayerState([...nextTwo, ...restOfDeck]);

--- a/src/common/util/game.js
+++ b/src/common/util/game.js
@@ -1,11 +1,11 @@
 import {
   chain as _, cloneDeep, compact, filter, findKey, flatMap,
-  intersection, isArray, mapValues, some, times, uniqBy
+  intersection, isArray, mapValues, shuffle, some, times, uniqBy
 } from 'lodash';
 import seededRNG from 'seed-random';
 
 import {
-  MAX_HAND_SIZE, BLUE_PLACEMENT_HEXES, ORANGE_PLACEMENT_HEXES,
+  DEFAULT_GAME_MODE, MAX_HAND_SIZE, BLUE_PLACEMENT_HEXES, ORANGE_PLACEMENT_HEXES,
   TYPE_ROBOT, TYPE_STRUCTURE, TYPE_CORE, stringToType
 } from '../constants';
 import defaultState, { bluePlayerState, orangePlayerState, arbitraryPlayerState } from '../store/defaultGameState';
@@ -257,12 +257,30 @@ export function logAction(state, player, action, cards, timestamp, target = null
   return state;
 }
 
-export function newGame(state, player, usernames, decks, seed = 0) {
-  state = Object.assign(state, cloneDeep(defaultState), {player: player, rng: seededRNG(seed)}); // Reset game state.
-  state.usernames = usernames;
-  state.players.blue = bluePlayerState(decks.blue);
-  state.players.orange = orangePlayerState(decks.orange);
-  state.started = true;
+// gameMode can be 'normal' or 'sharedDeck'
+export function newGame(state, player, usernames, decks, seed = 0, gameMode = DEFAULT_GAME_MODE) {
+  // Reset game state.
+  state = Object.assign(state, cloneDeep(defaultState), {
+    gameMode,
+    player: player,
+    rng: seededRNG(seed),
+    started: true,
+    usernames
+  });
+
+  if (gameMode === 'normal') {
+    state.players.blue = bluePlayerState(decks.blue);
+    state.players.orange = orangePlayerState(decks.orange);
+  } else if (gameMode === 'sharedDeck') {
+    const deck = shuffle([...decks.blue, ...decks.orange]);
+    // Give blue the top two cards, orange the next two, and both players the rest of the deck.
+    const [topTwo, nextTwo, restOfDeck] = [deck.slice(0, 2), deck.slice(2, 4), deck.slice(4)];
+    state.players.blue = bluePlayerState([...topTwo, ...restOfDeck]);
+    state.players.orange = orangePlayerState([...nextTwo, ...restOfDeck]);
+  } else {
+    throw `Unknown game mode: ${gameMode}`;
+  }
+
   state = triggerSound(state, 'yourmove.wav');
   return state;
 }
@@ -349,6 +367,7 @@ function endTurn(state) {
 }
 
 export function drawCards(state, player, count) {
+  const otherPlayer = state.players[opponent(player.name)];
   // Allow 1 extra card if an event is played (because that card will be discarded).
   const maxHandSize = MAX_HAND_SIZE + (state.eventExecuting ? 1 : 0);
 
@@ -357,12 +376,20 @@ export function drawCards(state, player, count) {
 
   if (numCardsDrawn > 0) {
     player.hand = player.hand.concat(player.deck.splice(0, numCardsDrawn));
+    if (state.gameMode === 'sharedDeck') {
+      // In sharedDeck mode, drawing a card (or discarding the top card of the deck)
+      // affects both players' decks.
+      otherPlayer.deck.splice(0, numCardsDrawn);
+    }
   }
 
   times(numCardsDiscarded, () => {
     const card = player.deck[0];
     if (card) {
       player.deck.splice(0, 1);
+      if (state.gameMode === 'sharedDeck') {
+        otherPlayer.deck.splice(0, 1);
+      }
       player.discardPile = player.discardPile.concat([card]);
       state = logAction(state, player, `had to discard |${card.name}| due to having a full hand of ${MAX_HAND_SIZE} cards`, {
         [card.name]: card

--- a/test/reducers/game.spec.js
+++ b/test/reducers/game.spec.js
@@ -5,7 +5,8 @@ import * as actions from '../../src/common/actions/game';
 import defaultState from '../../src/common/store/defaultGameState';
 import * as cards from '../../src/common/store/cards';
 import {
-  BLUE_CORE_HEX, ORANGE_CORE_HEX, STARTING_PLAYER_HEALTH, TYPE_ROBOT, TYPE_STRUCTURE
+  BLUE_CORE_HEX, ORANGE_CORE_HEX, STARTING_PLAYER_HEALTH, DECK_SIZE,
+  TYPE_ROBOT, TYPE_STRUCTURE
 } from '../../src/common/constants';
 import { getCost } from '../../src/common/util/game';
 import {
@@ -722,6 +723,20 @@ describe('Game reducer', () => {
       currentHand = hand();
       state = activate(state, '2,1,-3', 0, {card: 0});
       expect(hand()).toEqual(currentHand);
+    });
+  });
+
+  describe('[Shared deck mode]', () => {
+    it('should share decks', () => {
+      let state = getDefaultState('sharedDeck');
+      expect(state.players.blue.deck).toEqual(state.players.orange.deck);
+      expect(state.players.blue.deck.length + state.players.blue.hand.length + state.players.orange.hand.length).toEqual(DECK_SIZE * 2);
+
+      state = newTurn(state, 'orange');
+      expect(state.players.blue.deck).toEqual(state.players.orange.deck);
+
+      state = newTurn(state, 'blue');
+      expect(state.players.blue.deck).toEqual(state.players.orange.deck);
     });
   });
 });

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -1,6 +1,6 @@
 import { cloneDeep, findIndex, forOwn, has, isArray, isObject, mapValues, pickBy } from 'lodash';
 
-import { BLUE_CORE_HEX, ORANGE_CORE_HEX } from '../src/common/constants';
+import { DECK_SIZE, BLUE_CORE_HEX, ORANGE_CORE_HEX } from '../src/common/constants';
 import {
   opponent, allObjectsOnBoard, ownerOf, getAttribute, validPlacementHexes,
   drawCards, applyAbilities
@@ -19,10 +19,10 @@ import HexUtils from '../src/common/components/hexgrid/HexUtils';
 
 import { attackBotCard } from './data/cards';
 
-export function getDefaultState() {
+export function getDefaultState(gameMode = null) {
   const state = cloneDeep(defaultGameState);
-  const deck = [instantiateCard(attackBotCard)].concat(collection);
-  const simulatedGameStartAction = {type: socketActions.GAME_START, payload: {decks: {orange: deck, blue: deck}}};
+  const deck = [instantiateCard(attackBotCard)].concat(collection.slice(1, DECK_SIZE));
+  const simulatedGameStartAction = {type: socketActions.GAME_START, payload: {decks: {orange: deck, blue: deck}, gameMode}};
   return game(state, simulatedGameStartAction);
 }
 

--- a/test/testHelpers.js
+++ b/test/testHelpers.js
@@ -22,7 +22,13 @@ import { attackBotCard } from './data/cards';
 export function getDefaultState(gameMode = null) {
   const state = cloneDeep(defaultGameState);
   const deck = [instantiateCard(attackBotCard)].concat(collection.slice(1, DECK_SIZE));
-  const simulatedGameStartAction = {type: socketActions.GAME_START, payload: {decks: {orange: deck, blue: deck}, gameMode}};
+  const simulatedGameStartAction = {
+    type: socketActions.GAME_START,
+    payload: {
+      decks: {orange: deck, blue: deck},
+      gameMode
+    }
+  };
   return game(state, simulatedGameStartAction);
 }
 


### PR DESCRIPTION
In `sharedDeck` mode, both players use the same deck. This means that the two player's decks are shuffled together at the start of the game, and whenever a player draws from the deck, that card is removed from both players' "decks". Though each player technically has their own "deck" in this implementation, these two decks should always be exactly equal.

No UI/UX for starting sharedDeck games yet. For now you have to set the `DEFAULT_GAME_MODE` constant to test it.