### PR TITLE
Smarter carousel behavior

### DIFF
--- a/src/common/components/cards/CardCreationForm.js
+++ b/src/common/components/cards/CardCreationForm.js
@@ -26,6 +26,7 @@ const exampleStore = new CardTextExampleStore();
 
 export default class CardCreationForm extends Component {
   static propTypes = {
+    id: string,
     name: string,
     type: number,
     text: string,
@@ -50,7 +51,7 @@ export default class CardCreationForm extends Component {
 
   componentDidMount() {
     // Generate new spriteID on reload.
-    if (!this.props.isNewCard) {
+    if (!this.props.id) {
       this.props.onSpriteClick();
     }
 
@@ -367,7 +368,7 @@ export default class CardCreationForm extends Component {
             <RaisedButton
               primary
               fullWidth
-              label={this.props.isNewCard ? 'Save Edits' : 'Add to Collection'}
+              label={this.props.isNewCard ? 'Add to Collection' : 'Save Edits'}
               disabled={!this.isValid}
               style={this.styles.saveButton}
               onTouchTap={this.props.onAddToCollection} />

--- a/src/common/components/cards/RecentCardsCarousel.js
+++ b/src/common/components/cards/RecentCardsCarousel.js
@@ -38,6 +38,7 @@ export default class RecentCardsCarousel extends Component {
         <div>
           <Carousel dots infinite autoplay pauseOnHover
             arrows={false}
+            draggable={false}
             speed={500}
             autoplaySpeed={1500}
             slidesToScroll={1}

--- a/src/common/containers/Creator.js
+++ b/src/common/containers/Creator.js
@@ -25,7 +25,8 @@ export function mapStateToProps(state) {
     spriteID: state.creator.spriteID,
     sentences: state.creator.sentences,
     text: state.creator.text,
-    loggedIn: state.global.user !== null
+    loggedIn: state.global.user !== null,
+    cards: state.collection.cards
   };
 }
 
@@ -71,6 +72,7 @@ export class Creator extends Component {
     health: number,
     cost: number,
     loggedIn: bool,
+    cards: arrayOf(object),
 
     history: oneOfType([arrayOf(object), object]),
 
@@ -117,6 +119,7 @@ export class Creator extends Component {
         <div style={{display: 'flex', justifyContent: 'space-between'}}>
           <CardCreationForm
             loggedIn={this.props.loggedIn}
+            id={this.props.id}
             name={this.props.name}
             type={this.props.type}
             attack={this.props.attack}
@@ -125,7 +128,7 @@ export class Creator extends Component {
             energy={this.props.cost}
             text={this.props.text}
             sentences={this.props.sentences}
-            isNewCard={this.props.id ? true : false}
+            isNewCard={!(this.props.id && this.props.cards.find(card => card.id === this.props.id))}
             onSetName={this.props.onSetName}
             onSetType={this.props.onSetType}
             onSetText={this.props.onSetText}

--- a/styles/index.css
+++ b/styles/index.css
@@ -70,6 +70,11 @@ a.topLink:hover {
   color: #eee;
 }
 
+.slick-slider div {
+  outline: none;
+  user-select: none;
+}
+
 /* moz Sprite Fix */
 
 .wb-sprite {

--- a/styles/index.css
+++ b/styles/index.css
@@ -70,9 +70,8 @@ a.topLink:hover {
   color: #eee;
 }
 
-.slick-slider div {
+.slick-slider div:focus {
   outline: none;
-  user-select: none;
 }
 
 /* moz Sprite Fix */


### PR DESCRIPTION
#661.

Correctly handle `isNewCard` when a card was clicked from the recent cards carousel. Also, disallow dragging in the carousel and don't display a box when clicking a card.