### PR TITLE
Deck edit screen improvements: display set name, validation checkmarks, and more

### DIFF
--- a/src/common/components/cards/ActiveDeck.tsx
+++ b/src/common/components/cards/ActiveDeck.tsx
@@ -11,14 +11,21 @@ import Tooltip from '../Tooltip';
 import MustBeLoggedIn from '../users/MustBeLoggedIn';
 
 import ActiveDeckCard from './ActiveDeckCard';
+import DeckValidationIndicator from './DeckValidationIndicator';
 import { CardWithCount } from './types';
 
 interface ActiveDeckProps {
   id: w.DeckId | null
   cards: w.CardInStore[]
-  description?: string  // (only for sets)
   name: string
+
   isASet?: boolean  // otherwise, a deck
+  // Only for decks:
+  deck?: w.DeckInStore
+  setForDeck?: w.Set
+  // Only for sets:
+  description?: string
+
   loggedIn: boolean
   onIncreaseCardCount?: (cardId: w.CardId) => void
   onDecreaseCardCount?: (cardId: w.CardId) => void
@@ -73,7 +80,7 @@ export default class ActiveDeck extends React.Component<ActiveDeckProps, ActiveD
   }
 
   public render(): JSX.Element {
-    const { cards, isASet } = this.props;
+    const { cards, isASet, deck, setForDeck } = this.props;
     const { description, name } = this.state;
 
     return (
@@ -107,6 +114,13 @@ export default class ActiveDeck extends React.Component<ActiveDeckProps, ActiveD
               '30 '
           }
           ]
+          {
+            !isASet && (
+              <div style={{ float: 'right' }}>
+                <DeckValidationIndicator hideNumCards cards={cards} deck={deck} set={setForDeck}  />
+              </div>
+            )
+          }
         </div>
 
         <TextField
@@ -122,6 +136,16 @@ export default class ActiveDeck extends React.Component<ActiveDeckProps, ActiveD
           style={{width: '100%', marginBottom: 10}}
           onChange={this.handleChangeDescription}
         />}
+
+        {
+          setForDeck &&
+            <TextField
+              disabled
+              floatingLabelText="For the set:"
+              value={`${setForDeck.name} by ${setForDeck.metadata.authorName}`}
+              style={{width: '100%', marginBottom: 10, marginTop: -20}}
+            />
+        }
 
         <div>
           <div

--- a/src/common/components/cards/DeckSummary.tsx
+++ b/src/common/components/cards/DeckSummary.tsx
@@ -1,18 +1,16 @@
 import Paper from '@material-ui/core/Paper';
 import { filter, sortBy } from 'lodash';
 import Badge from 'material-ui/Badge';
-import FontIcon from 'material-ui/FontIcon';
 import * as React from 'react';
 
 import { TYPE_EVENT, TYPE_ROBOT, TYPE_STRUCTURE } from '../../constants';
 import * as w from '../../types';
 import { groupCards } from '../../util/cards';
-import { BUILTIN_FORMATS, SetFormat } from '../../util/formats';
 import ButtonInRow from '../ButtonInRow';
 import CardTooltip from '../card/CardTooltip';
-import Tooltip from '../Tooltip';
 import MustBeLoggedIn from '../users/MustBeLoggedIn';
 
+import DeckValidationIndicator from './DeckValidationIndicator';
 import { CardWithCount } from './types';
 
 interface DeckSummaryProps {
@@ -60,12 +58,6 @@ export default class DeckSummary extends React.Component<DeckSummaryProps> {
         display: 'flex',
         alignItems: 'center',
         fontWeight: 'bold'
-      },
-      validFormatsNote: {
-        cursor: 'help',
-        fontSize: '0.5em',
-        marginLeft: -5,
-        marginRight: 5
       }
     };
   }
@@ -77,21 +69,6 @@ export default class DeckSummary extends React.Component<DeckSummaryProps> {
   public render(): JSX.Element {
     const { cards, deck, set } = this.props;
     const [robots, structures, events] = [TYPE_ROBOT, TYPE_STRUCTURE, TYPE_EVENT].map((t) => filter(cards, ['type', t]));
-    const isComplete = (cards.length === 30);
-    const validatedDeck = {...deck, cards };
-
-    const isValidInSetFormat = set && new SetFormat(set).isDeckValid(validatedDeck);
-    const numValidBuiltinFormats = BUILTIN_FORMATS.filter((format) => format.isDeckValid(validatedDeck)).length;
-    const numValidFormats = numValidBuiltinFormats + (isValidInSetFormat ? 1 : 0);
-    const redX = '<span style="color: red;">X</span>';
-    const greenCheck = '<span style="color: green;">✓</span>';
-    const setFormatHTML = isValidInSetFormat
-      ? `${greenCheck} valid in the '${set!.name}' set (by ${set!.metadata.authorName}) format`
-      : `${redX} not valid in any Set formats`;
-    const validFormatsHTML = BUILTIN_FORMATS.map((format) =>
-      `${format.isDeckValid(validatedDeck) ? `${greenCheck} valid` : `${redX} not valid`} in ${format.displayName} format`
-    ).concat(setFormatHTML)
-     .join('<br>');
 
     return (
       <Paper
@@ -103,30 +80,7 @@ export default class DeckSummary extends React.Component<DeckSummaryProps> {
             {deck.name}
           </div>
 
-          <div
-            style={{
-              flex: 1,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              textAlign: 'right',
-              fontSize: 24,
-              color: (isComplete ? 'green' : 'red')
-            }}
-          >
-            <Tooltip inline html text={validFormatsHTML} style={{textAlign: 'left'}}>
-              <FontIcon
-                className="material-icons"
-                style={{paddingRight: 5, color: (isComplete ? 'green' : 'red') }}
-              >
-                {isComplete ? 'done' : 'warning'}
-              </FontIcon>
-              <sup style={this.styles.validFormatsNote}>
-                {numValidFormats}&thinsp;[?]
-              </sup>
-            </Tooltip>
-            {cards.length} cards
-          </div>
+          <DeckValidationIndicator deck={deck} cards={cards} set={set} />
         </div>
 
         <MustBeLoggedIn

--- a/src/common/components/cards/DeckValidationIndicator.tsx
+++ b/src/common/components/cards/DeckValidationIndicator.tsx
@@ -14,9 +14,9 @@ interface DeckValidationIndicatorProps {
 
 export default class DeckValidationIndicator extends React.Component<DeckValidationIndicatorProps> {
   get deck(): w.Deck {
-    const { cards, deck } = this.props;
-    const dummyDeck: w.DeckInStore = { id: '', name: '', cardIds: [], setId: null };
-    return  {...(deck || dummyDeck), cards };
+    const { cards, deck, set } = this.props;
+    const dummyDeck = { id: '', name: '', cardIds: [] };
+    return  {...(deck || dummyDeck), cards, setId: set ? set.id : null };
   }
 
   get isValidInSetFormat(): boolean {

--- a/src/common/components/cards/DeckValidationIndicator.tsx
+++ b/src/common/components/cards/DeckValidationIndicator.tsx
@@ -1,0 +1,85 @@
+import FontIcon from 'material-ui/FontIcon';
+import * as React from 'react';
+
+import * as w from '../../types';
+import { BUILTIN_FORMATS, SetFormat } from '../../util/formats';
+import Tooltip from '../Tooltip';
+
+interface DeckValidationIndicatorProps {
+  cards: w.CardInStore[]
+  deck?: w.DeckInStore
+  set?: w.Set
+  hideNumCards?: boolean
+}
+
+export default class DeckValidationIndicator extends React.Component<DeckValidationIndicatorProps> {
+  get deck(): w.Deck {
+    const { cards, deck } = this.props;
+    const dummyDeck: w.DeckInStore = { id: '', name: '', cardIds: [], setId: null };
+    return  {...(deck || dummyDeck), cards };
+  }
+
+  get isValidInSetFormat(): boolean {
+    return !!this.props.set && new SetFormat(this.props.set).isDeckValid(this.deck);
+  }
+
+  get numValidFormats(): number {
+    const numValidBuiltinFormats = BUILTIN_FORMATS.filter((format) => format.isDeckValid(this.deck)).length;
+    return numValidBuiltinFormats + (this.isValidInSetFormat ? 1 : 0);
+  }
+
+  get isValid(): boolean {
+    return this.numValidFormats > 0;
+  }
+
+  get validFormatsHTML(): string {
+    const { set } = this.props;
+    const redX = '<span style="color: red;">X</span>';
+    const greenCheck = '<span style="color: green;">✓</span>';
+    const setFormatHTML = this.isValidInSetFormat
+      ? `${greenCheck} valid in the '${set!.name}' set (by ${set!.metadata.authorName}) format`
+      : `${redX} not valid in any Set formats`;
+
+    return BUILTIN_FORMATS.map((format) =>
+      `${format.isDeckValid(this.deck) ? `${greenCheck} valid` : `${redX} not valid`} in ${format.displayName} format`
+    ).concat(setFormatHTML)
+     .join('<br>');
+  }
+
+  public render(): JSX.Element {
+    const { cards, hideNumCards } = this.props;
+    return (
+      <div
+        style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          textAlign: 'right',
+          fontSize: 24,
+          fontWeight: 'normal',
+          color: (this.isValid ? 'green' : 'red')
+        }}
+      >
+        <Tooltip inline html text={this.validFormatsHTML} style={{textAlign: 'left'}} additionalStyles={{cursor: 'help'}}>
+          <FontIcon
+            className="material-icons"
+            style={{paddingRight: 5, color: (this.isValid ? 'green' : 'red') }}
+          >
+            {this.isValid ? 'done' : 'warning'}
+          </FontIcon>
+          <sup
+            style={{
+              fontSize: '0.5em',
+              marginLeft: -5,
+              marginRight: 5
+            }}
+          >
+            {this.numValidFormats}&thinsp;[?]
+          </sup>
+        </Tooltip>
+        {!hideNumCards && `${cards.length} cards`}
+      </div>
+    );
+  }
+}

--- a/src/common/containers/Deck.tsx
+++ b/src/common/containers/Deck.tsx
@@ -89,16 +89,17 @@ export class Deck extends React.Component<DeckProps, DeckState> {
     };
   }
 
-  get cardPool(): w.CardInStore[] {
-    const { cards, sets } = this.props;
+  get set(): w.Set | undefined {
+    const { sets } = this.props;
     const { setId } = this.state;
 
     if (setId) {
-      const set = sets.find((s) => s.id === setId);
-      return set ? set.cards : [];
-    } else {
-      return cards;
+      return sets.find((s) => s.id === setId);
     }
+  }
+
+  get cardPool(): w.CardInStore[] {
+    return this.set ? this.set.cards : this.props.cards;
   }
 
   get selectedCards(): w.CardInStore[] {
@@ -149,6 +150,8 @@ export class Deck extends React.Component<DeckProps, DeckState> {
                 id={id}
                 name={deck ? deck.name : ''}
                 cards={this.selectedCards}
+                deck={deck || undefined}
+                setForDeck={this.set}
                 loggedIn={loggedIn}
                 onIncreaseCardCount={this.handleClickIncreaseCardCount}
                 onDecreaseCardCount={this.handleClickDecreaseCardCount}

--- a/src/common/containers/Sets.tsx
+++ b/src/common/containers/Sets.tsx
@@ -25,6 +25,7 @@ interface SetsStateProps {
 }
 
 interface SetsDispatchProps {
+  onCreateDeck: () => void
   onDeleteSet: (setId: string) => void
   onDuplicateSet: (setId: string) => void
   onEditSet: (setId: string) => void
@@ -47,6 +48,9 @@ function mapStateToProps(state: w.State): SetsStateProps {
 
 function mapDispatchToProps(dispatch: Dispatch<AnyAction>): SetsDispatchProps {
   return {
+    onCreateDeck: () => {
+      dispatch(collectionActions.editDeck(null));
+    },
     onDeleteSet: (setId: string) => {
       dispatch(collectionActions.deleteSet(setId));
     },
@@ -238,6 +242,7 @@ class Sets extends React.Component<SetsProps, SetsState> {
   }
 
   private handleCreateDeckFromSet = (setId: string) => () => {
+    this.props.onCreateDeck();
     this.props.history.push(`/deck/for/set/${setId}`);
   }
 


### PR DESCRIPTION
Fix #1179, #1191, and #1194.

<img width="324" alt="Screen Shot 2019-07-23 at 1 34 54 AM" src="https://user-images.githubusercontent.com/415965/61696794-cfcaa600-acea-11e9-9069-5228be4ba5c5.png">
