### PR TITLE
Migrate from /users/:user/cards/ to single /cards/ collection in Firebase

### DIFF
--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -33,7 +33,7 @@
       "$key": {
         ".write": "auth != null && (!newData.exists() || newData.child('metadata/source/uid').val() == auth.uid) && (!data.exists() || (data.child('metadata/source/uid').val() == auth.uid))"
       },
-      ".indexOn": ["id", "metadata/source/uid", "metadata/updated"]
+      ".indexOn": ["id", "metadata/ownerId", "metadata/updated"]
     },
     "decks": {
       ".read": "true",

--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -18,14 +18,22 @@
       "$key": {
         ".write": "auth != null && (!newData.exists() || newData.child('metadata/authorId').val() == auth.uid) && (!data.exists() || (data.child('metadata/authorId').val() == auth.uid && (!newData.exists() || data.child('metadata/isPublished').val() != true)))"
       },
-      ".indexOn": ["timestamp", "metadata/authorId"]
+      ".indexOn": ["timestamp", "metadata/authorId", "metadata/numDecksCreated"]
     },
     "recentCards": {
+      /* deprecated */
       ".read": "true",
       "$key": {
         ".write": "!data.exists()"
       },
       ".indexOn": "timestamp"
+    },
+    "cards": {
+      ".read": "true",
+      "$key": {
+        ".write": "auth != null && (!newData.exists() || newData.child('metadata/source/uid').val() == auth.uid) && (!data.exists() || (data.child('metadata/source/uid').val() == auth.uid))"
+      },
+      ".indexOn": ["metadata/source/uid", "metadata/updated"]
     },
     "decks": {
       ".read": "true",

--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -33,7 +33,7 @@
       "$key": {
         ".write": "auth != null && (!newData.exists() || newData.child('metadata/source/uid').val() == auth.uid) && (!data.exists() || (data.child('metadata/source/uid').val() == auth.uid))"
       },
-      ".indexOn": ["metadata/source/uid", "metadata/updated"]
+      ".indexOn": ["id", "metadata/source/uid", "metadata/updated"]
     },
     "decks": {
       ".read": "true",

--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -31,9 +31,9 @@
     "cards": {
       ".read": "true",
       "$key": {
-        ".write": "auth != null && (!newData.exists() || newData.child('metadata/source/uid').val() == auth.uid) && (!data.exists() || (data.child('metadata/source/uid').val() == auth.uid))"
+        ".write": "auth != null && (!data.exists() || data.child('metadata/ownerId').val() == auth.uid) && (!newData.exists() || newData.child('metadata/ownerId').val() == auth.uid)"
       },
-      ".indexOn": ["id", "metadata/ownerId", "metadata/updated"]
+      ".indexOn": ["id", "metadata/ownerId", "metadata/updated", "metadata/source/uid"]
     },
     "decks": {
       ".read": "true",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "enzyme-adapter-react-16": "1.12.1",
     "eslint": "^5.0.0",
     "eslint-plugin-compat": "^3.1.1",
+    "eslint-plugin-flowtype": "^4.3.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-jest": "^22.0.0",
     "eslint-plugin-lodash": "^5.1.0",

--- a/src/common/actions/creator.ts
+++ b/src/common/actions/creator.ts
@@ -9,7 +9,7 @@ export const REGENERATE_SPRITE = 'REGENERATE_SPRITE';
 export const TOGGLE_WILL_CREATE_ANOTHER = 'TOGGLE_WILL_CREATE_ANOTHER';
 export const TOGGLE_PRIVATE = 'TOGGLE_PRIVATE';
 export const SAVE_CARD = 'SAVE_CARD';
-export const RESET_CARD_CREATOR = 'RESET_CARD_CREATOR';
+export const ADD_EXISTING_CARD_TO_COLLECTION = 'ADD_EXISTING_CARD_TO_COLLECTION';
 
 export function setName(name: string): w.Action {
   return {
@@ -64,7 +64,7 @@ export function togglePrivate(): w.Action {
   };
 }
 
-// Note: This action is consumed by the collection reducer! (TODO move this to collection/actions)
+// Note: This actions is consumed by the cardCreator AND collection reducers!
 export function saveCard(props: w.CreatorState): w.Action {
   return {
     type: SAVE_CARD,
@@ -72,8 +72,10 @@ export function saveCard(props: w.CreatorState): w.Action {
   };
 }
 
-export function resetCardCreator(): w.Action {
+// Note: This actions is consumed by the cardCreator AND collection reducers!
+export function addExistingCardToCollection(card: w.CardInStore): w.Action {
   return {
-    type: RESET_CARD_CREATOR
+    type: ADD_EXISTING_CARD_TO_COLLECTION,
+    payload: { card }
   };
 }

--- a/src/common/actions/creator.ts
+++ b/src/common/actions/creator.ts
@@ -8,8 +8,8 @@ export const PARSE_COMPLETE = 'PARSE_COMPLETE';
 export const REGENERATE_SPRITE = 'REGENERATE_SPRITE';
 export const TOGGLE_WILL_CREATE_ANOTHER = 'TOGGLE_WILL_CREATE_ANOTHER';
 export const TOGGLE_PRIVATE = 'TOGGLE_PRIVATE';
-export const ADD_TO_COLLECTION = 'ADD_TO_COLLECTION';
-export const ADD_EXISTING_CARD_TO_COLLECTION = 'ADD_EXISTING_CARD_TO_COLLECTION';
+export const SAVE_CARD = 'SAVE_CARD';
+export const RESET_CARD_CREATOR = 'RESET_CARD_CREATOR';
 
 export function setName(name: string): w.Action {
   return {
@@ -64,18 +64,16 @@ export function togglePrivate(): w.Action {
   };
 }
 
-// Note: This actions is consumed by the cardCreator AND collection reducers!
-export function addToCollection(props: w.CreatorState): w.Action {
+// Note: This action is consumed by the collection reducer! (TODO move this to collection/actions)
+export function saveCard(props: w.CreatorState): w.Action {
   return {
-    type: ADD_TO_COLLECTION,
+    type: SAVE_CARD,
     payload: props
   };
 }
 
-// Note: This actions is consumed by the cardCreator AND collection reducers!
-export function addExistingCardToCollection(card: w.CardInStore): w.Action {
+export function resetCardCreator(): w.Action {
   return {
-    type: ADD_EXISTING_CARD_TO_COLLECTION,
-    payload: { card }
+    type: RESET_CARD_CREATOR
   };
 }

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -40,6 +40,9 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
   public componentDidMount(): void {
     const { userId } = this.props;
 
+    // TODO cancel this subscription in componentWillUnmount(), to fix:
+    //   backend.js:1 Warning: Can't perform a React state update on an unmounted component.
+    //   This is a no-op, but it indicates a memory leak in your application.
     listenToCards((data) => {
       let recentCards: w.CardInStore[] = _(Object.values(data) as w.CardInStore[])
         .uniqBy('name')

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -60,7 +60,7 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
       }
 
       this.setState({ recentCards });
-    }, userId);
+    }, userId || null);
   }
 
   public render(): JSX.Element | null {

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -43,11 +43,14 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
     listenToCards((data) => {
       let recentCards: w.CardInStore[] = _(Object.values(data) as w.CardInStore[])
         .uniqBy('name')
-        // Filter out cards w/o text, cards w/o timestamp, private cards, duplicates, built-in cards, etc.
-        .filter((c: w.CardInStore) =>
-          !!c.text && !!c.metadata.updated && !c.metadata.isPrivate
-            && !c.metadata.duplicatedFrom && c.metadata.source.type === 'user' && (!userId || c.metadata.source.uid === userId
-        ))
+        .filter((c: w.CardInStore) =>  // Filter out all of the following from carousels:
+          !!c.text  // cards without text (uninteresting)
+            && !!c.metadata.updated  // cards without timestamp (can't order them)
+            && c.metadata.source.type === 'user'  // built-in cards
+            && !c.metadata.isPrivate  // private cards
+            && !c.metadata.duplicatedFrom  // duplicated cards
+            && !c.metadata.importedFromJson  // cards imported from JSON
+        )
         .orderBy((c: w.CardInStore) => c.metadata.updated, ['desc'])
         .slice(0, 10)
         .value();

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -43,7 +43,7 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
     // TODO cancel this subscription in componentWillUnmount(), to fix:
     //   backend.js:1 Warning: Can't perform a React state update on an unmounted component.
     //   This is a no-op, but it indicates a memory leak in your application.
-    listenToCards((data) => {
+    (this as any).listener = listenToCards((data) => {
       let recentCards: w.CardInStore[] = _(Object.values(data) as w.CardInStore[])
         .uniqBy('name')
         .filter((c: w.CardInStore) =>  // Filter out all of the following from carousels:
@@ -67,6 +67,10 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
 
       this.setState({ recentCards });
     }, userId || null);
+  }
+
+  public componentWillUnmount(): void {
+    (this as any).listener.off();
   }
 
   public render(): JSX.Element | null {

--- a/src/common/containers/App.tsx
+++ b/src/common/containers/App.tsx
@@ -21,7 +21,7 @@ import { MIN_WINDOW_WIDTH_TO_EXPAND_SIDEBAR, SIDEBAR_COLLAPSED_WIDTH, SIDEBAR_WI
 import PersonalTheme from '../themes/personal';
 import * as w from '../types';
 import { isFlagSet, logAnalytics } from '../util/browser';
-import { listenToSets, listenToUserData, onLogin, onLogout } from '../util/firebase';
+import { listenToCards, listenToSets, listenToUserData, onLogin, onLogout } from '../util/firebase';
 
 import About from './About';
 import Collection from './Collection';
@@ -110,6 +110,8 @@ class App extends React.Component<AppProps, AppState> {
 
     onLogin((user) => {
       onLoggedIn(user);
+      // TODO actually check that *all* Firebase data is loaded before setting loading: false
+      listenToCards((data) => onReceiveFirebaseData({ cards: Object.values(data) }), user.uid);
       listenToUserData((data) => {
         onReceiveFirebaseData(data);
         this.setState({ loading: false });

--- a/src/common/containers/Creator.tsx
+++ b/src/common/containers/Creator.tsx
@@ -50,7 +50,6 @@ interface CreatorDispatchProps {
   onSetAttribute: (attr: w.Attribute | 'cost', value: number) => void
   onParseComplete: (idx: number, sentence: string, result: w.ParseResult) => void
   onSpriteClick: () => void
-  onAddExistingCardToCollection: (card: w.CardInStore) => void
   onAddNewCardToCollection: (props: w.CreatorState) => void
   onToggleWillCreateAnother: () => void
   onToggleIsPrivate: () => void
@@ -107,10 +106,7 @@ export function mapDispatchToProps(dispatch: Dispatch): CreatorDispatchProps {
       dispatch(creatorActions.regenerateSprite());
     },
     onAddNewCardToCollection: (props: w.CreatorState) => {
-      dispatch(creatorActions.addToCollection(props));
-    },
-    onAddExistingCardToCollection: (props: w.CardInStore) => {
-      dispatch(creatorActions.addExistingCardToCollection(props));
+      dispatch(creatorActions.saveCard(props));
     },
     onToggleWillCreateAnother: () => {
       dispatch(creatorActions.toggleWillCreateAnother());
@@ -196,7 +192,7 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
               onSpriteClick={this.props.onSpriteClick}
               onOpenDialog={this.openDialog}
               onTestCard={this.testCard}
-              onAddToCollection={this.addToCollection}
+              onAddToCollection={this.saveCard}
               onToggleWillCreateAnother={this.props.onToggleWillCreateAnother}
             />
             <Paper style={{ padding: 10, marginTop: 20, paddingTop: cardOpenedForEditing ? 10 : 0 }}>
@@ -273,11 +269,12 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
     this.props.history.push('/play/sandbox', { previous: this.props.history.location });
   }
 
-  private addToCollection = (redirectToCollection: boolean) => {
-    const { onAddExistingCardToCollection, onAddNewCardToCollection, history } = this.props;
-    const { cardOpenedForEditing } = this.state;
+  private saveCard = (redirectToCollection: boolean) => {
+    const { onAddNewCardToCollection, history } = this.props;
 
-    if (cardOpenedForEditing) {
+    if (!this.isCardEditable) {
+      // TODO Instead of onAddExistingCardToCollection, we probably want to duplicate the card here
+      // and the button should maybe be called "ADD COPY"
       onAddExistingCardToCollection(cardOpenedForEditing);
     } else {
       onAddNewCardToCollection(this.props);

--- a/src/common/containers/Creator.tsx
+++ b/src/common/containers/Creator.tsx
@@ -50,6 +50,7 @@ interface CreatorDispatchProps {
   onSetAttribute: (attr: w.Attribute | 'cost', value: number) => void
   onParseComplete: (idx: number, sentence: string, result: w.ParseResult) => void
   onSpriteClick: () => void
+  onAddExistingCardToCollection: (card: w.CardInStore) => void
   onAddNewCardToCollection: (props: w.CreatorState) => void
   onToggleWillCreateAnother: () => void
   onToggleIsPrivate: () => void
@@ -107,6 +108,9 @@ export function mapDispatchToProps(dispatch: Dispatch): CreatorDispatchProps {
     },
     onAddNewCardToCollection: (props: w.CreatorState) => {
       dispatch(creatorActions.saveCard(props));
+    },
+    onAddExistingCardToCollection: (props: w.CardInStore) => {
+      dispatch(creatorActions.addExistingCardToCollection(props));
     },
     onToggleWillCreateAnother: () => {
       dispatch(creatorActions.toggleWillCreateAnother());
@@ -192,7 +196,7 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
               onSpriteClick={this.props.onSpriteClick}
               onOpenDialog={this.openDialog}
               onTestCard={this.testCard}
-              onAddToCollection={this.saveCard}
+              onAddToCollection={this.addToCollection}
               onToggleWillCreateAnother={this.props.onToggleWillCreateAnother}
             />
             <Paper style={{ padding: 10, marginTop: 20, paddingTop: cardOpenedForEditing ? 10 : 0 }}>
@@ -269,13 +273,12 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
     this.props.history.push('/play/sandbox', { previous: this.props.history.location });
   }
 
-  private saveCard = (redirectToCollection: boolean) => {
-    const { onAddNewCardToCollection, history } = this.props;
+  private addToCollection = (redirectToCollection: boolean) => {
+    const { onAddExistingCardToCollection, onAddNewCardToCollection, history } = this.props;
+    const { cardOpenedForEditing } = this.state;
 
     if (!this.isCardEditable) {
-      // TODO Instead of onAddExistingCardToCollection, we probably want to duplicate the card here
-      // and the button should maybe be called "ADD COPY"
-      onAddExistingCardToCollection(cardOpenedForEditing);
+      onAddExistingCardToCollection(cardOpenedForEditing!);
     } else {
       onAddNewCardToCollection(this.props);
     }

--- a/src/common/reducers/collection.ts
+++ b/src/common/reducers/collection.ts
@@ -21,11 +21,8 @@ export default function collection(oldState: State = defaultState, action: w.Act
       case globalActions.FIREBASE_DATA:
         return c.loadState(state, action.payload.data);
 
-      case creatorActions.ADD_TO_COLLECTION:
+      case creatorActions.SAVE_CARD:
         return c.saveCard(state, action.payload);
-
-      case creatorActions.ADD_EXISTING_CARD_TO_COLLECTION:
-        return c.saveExistingCard(state, action.payload.card);
 
       case collectionActions.DELETE_DECK:
         return c.deleteDeck(state, action.payload.deckId);

--- a/src/common/reducers/collection.ts
+++ b/src/common/reducers/collection.ts
@@ -22,7 +22,7 @@ export default function collection(oldState: State = defaultState, action: w.Act
         return c.loadState(state, action.payload.data);
 
       case creatorActions.ADD_TO_COLLECTION:
-        return c.saveCard(state, action.payload, !action.payload.isPrivate);
+        return c.saveCard(state, action.payload);
 
       case creatorActions.ADD_EXISTING_CARD_TO_COLLECTION:
         return c.saveExistingCard(state, action.payload.card);

--- a/src/common/reducers/collection.ts
+++ b/src/common/reducers/collection.ts
@@ -24,6 +24,9 @@ export default function collection(oldState: State = defaultState, action: w.Act
       case creatorActions.SAVE_CARD:
         return c.saveCard(state, action.payload);
 
+      case creatorActions.ADD_EXISTING_CARD_TO_COLLECTION:
+        return c.saveExistingCard(state, action.payload.card);
+
       case collectionActions.DELETE_DECK:
         return c.deleteDeck(state, action.payload.deckId);
 

--- a/src/common/reducers/creator.ts
+++ b/src/common/reducers/creator.ts
@@ -64,9 +64,7 @@ export default function creator(oldState: State = defaultState, { type, payload 
     case creatorActions.TOGGLE_PRIVATE:
       return {...state, isPrivate: !state.isPrivate};
 
-    case creatorActions.ADD_TO_COLLECTION:
-    case creatorActions.ADD_EXISTING_CARD_TO_COLLECTION:
-      // Reset card creator state.
+    case creatorActions.RESET_CARD_CREATOR:
       return {
         ...defaultState,
         willCreateAnother: state.willCreateAnother,

--- a/src/common/reducers/creator.ts
+++ b/src/common/reducers/creator.ts
@@ -64,7 +64,8 @@ export default function creator(oldState: State = defaultState, { type, payload 
     case creatorActions.TOGGLE_PRIVATE:
       return {...state, isPrivate: !state.isPrivate};
 
-    case creatorActions.RESET_CARD_CREATOR:
+    case creatorActions.SAVE_CARD:
+    case creatorActions.ADD_EXISTING_CARD_TO_COLLECTION:
       return {
         ...defaultState,
         willCreateAnother: state.willCreateAnother,

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -2,7 +2,7 @@ import { isUndefined, omitBy, pick } from 'lodash';
 
 import * as w from '../../types';
 import {
-  areIdenticalCards, cardsFromJson, cardsToJson, createCardFromProps, loadCardsFromFirebase,
+  cardsFromJson, cardsToJson, createCardFromProps, loadCardsFromFirebase,
   loadDecksFromFirebase, loadSetsFromFirebase, saveDecksToFirebase, splitSentences
 } from '../../util/cards';
 import { id } from '../../util/common';

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -164,11 +164,6 @@ const cardsHandlers = {
     return saveCard(state, card);
   },
 
-  saveExistingCard: (state: State, card: w.CardInStore): State => {
-    // e.g. used when importing a card from the RecentCardsCarousel
-    return saveCard(state, card);
-  },
-
   saveDeck: (state: State, deckId: string, name: string, cardIds: string[] = [], setId: string | null = null): State => {
     let deck: w.DeckInStore | undefined;
     if (deckId) {

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -214,15 +214,16 @@ function saveCard(state: State, card: w.CardInStore): State {
     // Editing an existing card.
     const { source } = existingCard.metadata;
     if (!source || source.type === 'builtin' || source.uid !== firebase.lookupCurrentUser()!.uid) {
-      // TODO Log warning about not being about not being able to replace builtin cards.
+      throw new Error("Can't edit this card! Maybe it's a built-in card or a card that doesn't belong to you?");
     } else {
       Object.assign(existingCard, card, {id: existingCard.id});
     }
   } else {
+    // Creating a new card.
     state.cards.push(card);
-    firebase.saveCard(card);
   }
 
+  firebase.saveCard(card);
   return state;
 }
 

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -3,7 +3,7 @@ import { isUndefined, omitBy, pick } from 'lodash';
 import * as w from '../../types';
 import {
   areIdenticalCards, cardsFromJson, cardsToJson, createCardFromProps, loadCardsFromFirebase,
-  loadDecksFromFirebase, loadSetsFromFirebase, saveCardToFirebase, saveDecksToFirebase, splitSentences
+  loadDecksFromFirebase, loadSetsFromFirebase, saveDecksToFirebase, splitSentences
 } from '../../util/cards';
 import { id } from '../../util/common';
 import * as firebase from '../../util/firebase';
@@ -221,7 +221,7 @@ function saveCard(state: State, card: w.CardInStore): State {
     }
   } else {
     state.cards.push(card);
-    saveCardToFirebase(card);
+    firebase.saveCard(card);
   }
 
   return state;

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -43,6 +43,7 @@ const cardsHandlers = {
         id: id(),
         name: `Copy of ${originalCard.name}`,
         metadata: {
+          ownerId: currentUser.uid,
           source: { type: 'user', uid: currentUser.uid, username: currentUser.displayName! },
           created: Date.now(),
           updated: Date.now(),
@@ -161,6 +162,11 @@ const cardsHandlers = {
 
   saveCard: (state: State, cardProps: w.CreatorState): State => {
     const card = createCardFromProps(cardProps);
+    return saveCard(state, card);
+  },
+
+  saveExistingCard: (state: State, card: w.CardInStore): State => {
+    // e.g. used when importing a card from the RecentCardsCarousel
     return saveCard(state, card);
   },
 

--- a/src/common/reducers/handlers/cards.ts
+++ b/src/common/reducers/handlers/cards.ts
@@ -206,10 +206,8 @@ const cardsHandlers = {
 
 // Saves a card, either as a new card or replacing an existing card.
 function saveCard(state: State, card: w.CardInStore): State {
-
-  // Is there already a card with the same ID (i.e. we're currently editing it)
-  // or that is identical to the saved card (i.e. we're replacing it with a card with the same name)?
-  const existingCard = state.cards.find((c) => c.id === card.id || areIdenticalCards(c, card));
+  // Is there already a card with the same ID (i.e. we're currently editing it)?
+  const existingCard = state.cards.find((c) => c.id === card.id);
 
   if (existingCard) {
     // Editing an existing card.

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -93,6 +93,7 @@ export interface CardInStore {
     updated?: timestamp
     duplicatedFrom?: CardId
     isPrivate?: boolean
+    importedFromJson?: timestamp
   }
 }
 

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -7,6 +7,7 @@ import * as m from '../server/multiplayer/multiplayer';
 // Simple types
 
 type timestamp = number;
+type UserId = string;
 
 export type AbilityId = string;
 export type Attribute = 'attack' | 'health' | 'speed';
@@ -87,23 +88,26 @@ export interface CardInStore {
   command?: StringRepresentationOf<(state: GameState) => any> | Array<StringRepresentationOf<(state: GameState) => any>>
   spriteV?: number
   parserV?: number | null
-  metadata: {
-    source: CardSource
-    created?: timestamp
-    updated?: timestamp
-    duplicatedFrom?: CardId
-    isPrivate?: boolean
-    importedFromJson?: timestamp
-  }
+  metadata: CardMetadata
 }
 
 export interface ObfuscatedCard {
   id: string
 }
 
+export interface CardMetadata {
+  ownerId?: UserId  // should only be undefined if source.type === 'builtin'
+  source: CardSource
+  created?: timestamp
+  updated?: timestamp
+  duplicatedFrom?: CardId
+  isPrivate?: boolean
+  importedFromJson?: timestamp
+}
+
 export interface CardSource {
   type: 'builtin' | 'user' | 'generated'  // For 'generated', see targets['generateCard']
-  uid?: string
+  uid?: UserId
   username?: string
 }
 

--- a/src/common/util/browser.tsx
+++ b/src/common/util/browser.tsx
@@ -72,3 +72,11 @@ export function getGameAreaNode(): HTMLElement {
 export function zeroWidthJoin(...items: React.ReactNode[]): React.ReactNode {
   return items.reduce((a, b) => <span>{a}&zwnj;{b}</span>);
 }
+
+// Sometimes we need to perform a firebase update inside a redux reducer, but
+// the firebase update needs to run right *after* we finish handling the action,
+// to avoid "You may not call store.getState() while the reducer is executing" exceptions.
+// The easiest solution for now is to just use setTimeout, but it's pretty gross. TODO find a better way.
+export function defer(fn: () => void): void {
+  setTimeout(fn, 0);
+}

--- a/src/common/util/browser.tsx
+++ b/src/common/util/browser.tsx
@@ -78,5 +78,10 @@ export function zeroWidthJoin(...items: React.ReactNode[]): React.ReactNode {
 // to avoid "You may not call store.getState() while the reducer is executing" exceptions.
 // The easiest solution for now is to just use setTimeout, but it's pretty gross. TODO find a better way.
 export function defer(fn: () => void): void {
-  setTimeout(fn, 0);
+  if (inBrowser()) {
+    setTimeout(fn, 0);
+  } else {
+    // This branch mainly for tests
+    fn();
+  }
 }

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -14,7 +14,7 @@ import defaultState from '../store/defaultCollectionState';
 import * as w from '../types';
 
 import { compareCertainKeys, id as generateId } from './common';
-import { indexParsedSentence, lookupCurrentUser, saveRecentCard, saveUserData } from './firebase';
+import { indexParsedSentence, lookupCurrentUser, saveCard, saveUserData } from './firebase';
 
 //
 // 1. Miscellaneous helper functions pertaining to cards.
@@ -373,8 +373,10 @@ export function cardsFromJson(json: string, callback: (card: w.CardInStore) => a
       id: generateId(),
       metadata: {
         ...card.metadata,
-        created: card.metadata.created || Date.now(),
-        updated: card.metadata.updated || Date.now()
+        source: cardSourceForCurrentUser(),
+        duplicatedFrom: 'json-import',  // TODO maybe this should be a separate metadata field
+        created: (card.metadata && card.metadata.created) || Date.now(),
+        updated: Date.now()
       }
     }))
     .forEach((card: w.CardInStore) => { parseCard(card, callback); });
@@ -441,13 +443,8 @@ export function loadSetsFromFirebase(state: w.CollectionState, data: any): w.Col
 export function saveCardToFirebase(card: w.CardInStore): void {
   // No point in keeping track of recent "vanilla" (text-less) cards
   if (card.text) {
-    saveRecentCard(card);
+    saveCard(card);
   }
-}
-
-// Saves a card to the user's collection
-export function saveCardsToFirebase(state: w.CollectionState): void {
-  saveUserData('cards', state.cards.filter((c) => c.metadata.source.type !== 'builtin'));
 }
 
 export function saveDecksToFirebase(state: w.CollectionState): void {

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -374,9 +374,9 @@ export function cardsFromJson(json: string, callback: (card: w.CardInStore) => a
       metadata: {
         ...card.metadata,
         source: cardSourceForCurrentUser(),
-        duplicatedFrom: 'json-import',  // TODO maybe this should be a separate metadata field
         created: (card.metadata && card.metadata.created) || Date.now(),
-        updated: Date.now()
+        updated: Date.now(),
+        importedFromJson: Date.now()
       }
     }))
     .forEach((card: w.CardInStore) => { parseCard(card, callback); });

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -14,7 +14,7 @@ import defaultState from '../store/defaultCollectionState';
 import * as w from '../types';
 
 import { compareCertainKeys, id as generateId } from './common';
-import { indexParsedSentence, lookupCurrentUser, saveCard, saveUserData } from './firebase';
+import { indexParsedSentence, lookupCurrentUser, saveUserData } from './firebase';
 
 //
 // 1. Miscellaneous helper functions pertaining to cards.
@@ -407,7 +407,7 @@ export function normalizeCard(card: w.CardInStore, set?: w.Set): w.CardInStore {
   };
 }
 
-export function loadCardsFromFirebase(state: w.CollectionState, data: any): w.CollectionState {
+export function loadCardsFromFirebase(state: w.CollectionState, data?: any): w.CollectionState {
   if (data) {
     if (data.cards) {
       const cardsFromFirebase = data.cards.map(normalizeCard) || [];
@@ -437,14 +437,6 @@ export function loadSetsFromFirebase(state: w.CollectionState, data: any): w.Col
     ...state,
     sets: data ? (data.sets ? (data.sets as w.Set[]).map(normalizeCards) : state.sets) : defaultState.sets
   };
-}
-
-// Saves a card to the Recent Cards carousel
-export function saveCardToFirebase(card: w.CardInStore): void {
-  // No point in keeping track of recent "vanilla" (text-less) cards
-  if (card.text) {
-    saveCard(card);
-  }
 }
 
 export function saveDecksToFirebase(state: w.CollectionState): void {

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -13,22 +13,12 @@ import * as g from '../guards';
 import defaultState from '../store/defaultCollectionState';
 import * as w from '../types';
 
-import { compareCertainKeys, id as generateId } from './common';
+import { id as generateId } from './common';
 import { indexParsedSentence, lookupCurrentUser, saveUserData } from './firebase';
 
 //
 // 1. Miscellaneous helper functions pertaining to cards.
 //
-
-export function areIdenticalCards(card1: w.CardInStore, card2: w.CardInStore): boolean {
-  // Ignore if one card is explicitly a duplicate of the other.
-  if ((card2.metadata.duplicatedFrom === card1.id) || (card1.metadata.duplicatedFrom === card2.id)) {
-    return false;
-  }
-
-  // TODO: Check abilities/command rather than text.
-  return compareCertainKeys(card1, card2, ['type', 'cost', 'text', 'stats']);
-}
 
 export function cardsInDeck(deck: w.DeckInStore, userCards: w.CardInStore[], sets: w.Set[]): w.CardInStore[] {
   const set: w.Set | null = deck.setId && sets.find((s) => s.id === deck.setId) || null;

--- a/src/common/util/common.ts
+++ b/src/common/util/common.ts
@@ -1,4 +1,4 @@
-import {clamp as _clamp, fromPairs, isEqual, isNaN, isString, some} from 'lodash';
+import {clamp as _clamp, fromPairs, isEqual, isNaN, isObject, isString, isUndefined, some} from 'lodash';
 
 import * as w from '../types';
 
@@ -74,4 +74,17 @@ export function animate(fns: Array<() => void>, delay: number): void {
     first();
     setTimeout(() => animate(rest, delay), delay);
   }
+}
+
+// Removes all undefined (but not null) fields recursively from an object.
+// Based on https://stackoverflow.com/a/38340730/2608804
+// TODO this can be cleaned up a lot with Object.fromEntries() after we upgrade to TypeScript 3.x
+export function withoutEmptyFields<T extends object>(obj: T): T {
+  return Object.entries(obj)
+    .filter(([_k, v]) => !isUndefined(v))
+    .reduce(
+      // tslint:disable-next-line prefer-object-spread (object spread here doesn't type-check due to a bug in TypeScript <3.2)
+      (newObjSoFar, [k, v]) => Object.assign({}, newObjSoFar as T, { [k]: isObject(v) ? withoutEmptyFields(v) : v }),
+      {} as T
+    );
 }

--- a/src/common/util/firebase.ts
+++ b/src/common/util/firebase.ts
@@ -141,7 +141,7 @@ export function saveGame(game: w.SavedGame): firebase.database.ThenableReference
 /** Returns either all cards for a given user or the most recent cards belonging to any user. */
 export function listenToCards(callback: (data: any) => any, uid: string | null): void {
   const ref = uid
-    ? fb.database().ref('cards').orderByChild('metadata/source/uid').equalTo(uid)
+    ? fb.database().ref('cards').orderByChild('metadata/ownerId').equalTo(uid)
     : fb.database().ref('cards').orderByChild('metadata/updated').limitToLast(50);
 
   ref.on('value', (snapshot: firebase.database.DataSnapshot) => {

--- a/src/common/util/firebase.ts
+++ b/src/common/util/firebase.ts
@@ -55,10 +55,6 @@ function getLoggedInUser(): Promise<firebase.User> {
 }
 
 export function lookupCurrentUser(): firebase.User | null {
-  if (inTest()) {
-    return { uid: 'test-user-id', displayName: 'test-user-name' } as firebase.User;
-  }
-
   return currentUser;
 }
 

--- a/src/common/util/firebase.ts
+++ b/src/common/util/firebase.ts
@@ -1,6 +1,6 @@
 import { UserCredential } from '@firebase/auth-types';
 import * as firebase from 'firebase/app';
-import { capitalize, concat, flatMap, fromPairs, identity, isUndefined, mapValues, omitBy, orderBy, uniq, uniqBy } from 'lodash';
+import { capitalize, concat, flatMap, fromPairs, identity, mapValues, orderBy, uniq, uniqBy } from 'lodash';
 
 const fb = require('firebase/app').default;
 import 'firebase/auth';
@@ -10,6 +10,7 @@ import * as w from '../types';
 
 import { inTest } from './browser';
 import { expandKeywords, loadParserLexicon, normalizeCard } from './cards';
+import { withoutEmptyFields } from './common';
 
 const config = {
   apiKey: 'AIzaSyD6XsL6ViMw8_vBy6aU7Dj9F7mZJ8sxcUA',
@@ -142,7 +143,7 @@ export function saveGame(game: w.SavedGame): firebase.database.ThenableReference
 // Cards and text
 
 /** Returns either all cards for a given user or the most recent cards belonging to any user. */
-export function listenToCards(callback: (data: any) => any, uid?: string): void {
+export function listenToCards(callback: (data: any) => any, uid: string | null): void {
   const ref = uid
     ? fb.database().ref('cards').orderByChild('metadata/source/uid').equalTo(uid)
     : fb.database().ref('cards').orderByChild('metadata/updated').limitToLast(50);
@@ -227,7 +228,7 @@ export function saveCard(card: w.Card): void {
     // see firebaseRules.json - this save will only succeed if either:
     //   (i) there is no card yet with the given id
     //   (ii) the card with the given id was created by the logged-in user
-    .update(omitBy(card, isUndefined));
+    .update(withoutEmptyFields(card));
 }
 
 export function removeCards(cardIds: string[]): void {

--- a/test/reducers/collection.spec.ts
+++ b/test/reducers/collection.spec.ts
@@ -88,6 +88,7 @@ describe('Collection reducer', () => {
 
       // firebase.saveCard() should have been called twice (once for the creation, once for the edit)
       expect(firebase.saveCard).toHaveBeenCalledTimes(2);
+      expectCardsToBeEqual((firebase.saveCard as any).mock.calls[1][0], { ...testBotCard, cost: 2 });
     });
   });
 });

--- a/test/reducers/collection.spec.ts
+++ b/test/reducers/collection.spec.ts
@@ -1,29 +1,93 @@
-import { difference } from 'lodash';
+import { difference, noop, omit } from 'lodash';
 
 import { duplicateCard } from '../../src/common/actions/collection';
+import { saveCard } from '../../src/common/actions/creator';
+import { TYPE_ROBOT } from '../../src/common/constants';
 import collection from '../../src/common/reducers/collection';
 import defaultState from '../../src/common/store/defaultCollectionState';
 import * as w from '../../src/common/types';
+import { createCardFromProps } from '../../src/common/util/cards';
+import * as firebase from '../../src/common/util/firebase';
+
+jest.mock('../../src/common/util/firebase');
+
+function expectCardsToBeEqual(card1: w.CardInStore, card2: w.CardInStore): void {
+  expect(omit(card1, ['id', 'metadata'])).toEqual(omit(card2, ['id', 'metadata']));
+}
+
+function defaultCollectionState(): w.CollectionState {
+  return {
+    ...defaultState,
+    cards: [...defaultState.cards]
+  };
+}
 
 describe('Collection reducer', () => {
-  it('DUPLICATE_CARD', () => {
-    const state: w.CollectionState = defaultState;
-    const existingCards = [...defaultState.cards];
-    const oneBotCard: w.CardInStore = existingCards.find((c) => c.name === 'One Bot')!;
+  beforeAll(() => {
+    (firebase.lookupCurrentUser as any).mockImplementation(() => ({ uid: 'test-user-id', displayName: 'test-user-name' }));
+    (firebase.saveCard as any).mockImplementation(noop);
+  });
 
-    const newState = collection({...state}, duplicateCard(oneBotCard));
-    const newCards = difference(newState.cards, existingCards);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('DUPLICATE_CARD', () => {
+    let state: w.CollectionState = defaultCollectionState();
+    const oneBotCard: w.CardInStore = state.cards.find((c) => c.name === 'One Bot')!;
+    state = collection(state, duplicateCard(oneBotCard));
+
+    const newCards = difference(state.cards, defaultState.cards);
     expect(newCards.length).toEqual(1);
-    const newCard = newCards[0];
-    expect(newCard).toEqual({
-      ...oneBotCard,
-      id: newCard.id,
-      name: 'Copy of One Bot',
-      metadata: {
-        ...newCard.metadata,
-        source: { type: 'user', uid: 'test-user-id', username: 'test-user-name' },
-        duplicatedFrom: oneBotCard.id
-      }
+    expectCardsToBeEqual(newCards[0], { ...oneBotCard, name: 'Copy of One Bot' });
+    expect(firebase.saveCard).toHaveBeenCalledTimes(1);
+  });
+
+  describe('SAVE_CARD', () => {
+    const testBotCreatorState: w.CreatorState = {
+      attack: 1,
+      cost: 1,
+      health: 1,
+      id: null,
+      name: 'Test Bot',
+      parserVersion: null,
+      sentences: [],
+      speed: 1,
+      spriteID: '',
+      text: '',
+      type: TYPE_ROBOT,
+      willCreateAnother: false
+    };
+    const testBotCard: w.CardInStore = createCardFromProps(testBotCreatorState);  // tslint:disable-line mocha-no-side-effect-code
+
+    it('creates new card', () => {
+      let state: w.CollectionState = defaultCollectionState();
+      state = collection(state, saveCard(testBotCreatorState));
+
+      const newCards = difference(state.cards, defaultState.cards);
+      expect(newCards.length).toEqual(1);
+      expectCardsToBeEqual(newCards[0], testBotCard);
+      expect(firebase.saveCard).toHaveBeenCalledTimes(1);
+      expectCardsToBeEqual((firebase.saveCard as any).mock.calls[0][0], testBotCard);
+    });
+
+    it('edits existing cards', () => {
+      let state: w.CollectionState = defaultCollectionState();
+
+      // Create Test Bot ...
+      state = collection(state, saveCard(testBotCreatorState));
+      // ... then edit its cost to be 2
+      const testBotId: w.CardId = difference(state.cards, defaultState.cards)[0].id;
+      const editedTestBotCreatorState: w.CreatorState = { ...testBotCreatorState, id: testBotId, cost: 2 };
+      state = collection(state, saveCard(editedTestBotCreatorState));
+
+      // Only the edited card should be in the player's collection now
+      const newCards = difference(state.cards, defaultState.cards);
+      expect(newCards.length).toEqual(1);
+      expectCardsToBeEqual(newCards[0], { ...testBotCard, cost: 2 });
+
+      // firebase.saveCard() should have been called twice (once for the creation, once for the edit)
+      expect(firebase.saveCard).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/test/util/common.spec.ts
+++ b/test/util/common.spec.ts
@@ -1,0 +1,8 @@
+import { withoutEmptyFields } from '../../src/common/util/common';
+
+describe('withoutEmptyFields', () => {
+  it('should remove undefined fields recursively', () => {
+    const obj = { a: 1, b: 2, c: undefined, d: { e: 3, f: undefined, g: null } };
+    expect(withoutEmptyFields(obj)).toEqual({ a: 1, b: 2, d: { e: 3, g: null }});
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5092,6 +5092,13 @@ eslint-plugin-compat@^3.1.1:
     mdn-browser-compat-data "^0.0.72"
     semver "^5.6.0"
 
+eslint-plugin-flowtype@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.3.0.tgz#06d0837ac341caf369e7e6dbb112dd7fd21acf17"
+  integrity sha512-elvqoadMHnYqSYN1YXn02DR7SFW8Kc2CLe8na3m2GdQPQhIY+BgCd2quVJ1AbW3aO0zcyE9loVJ7Szy8A/xlMA==
+  dependencies:
+    lodash "^4.17.15"
+
 eslint-plugin-import@^2.9.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
@@ -9002,6 +9009,11 @@ lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.1
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
+
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@2.2.0, log-symbols@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
#1275, #1281, #1282.

The actual migration performed (not committed) was:

```typescript
import { chain as _, isUndefined, omit, omitBy } from 'lodash';
(window as any).migrate = () => {
  fb.database()
    .ref('users')
    .on('value', (snapshot: any) => {
      const cards: w.CardInStore[] = _(Object.values(snapshot.val()))
        .flatMap((user: any) =>
          (user.cards || []).map((card: w.CardInStore) =>
            normalizeCard(card, user.info ? { type: 'user', uid: user.info.uid, username: user.info.displayName } : undefined)
          )
        )
        .map((card: w.CardInStore) => ({
          ...omitBy(omit(card, ['source', 'timestamp']), isUndefined),
          metadata: {...omitBy(card.metadata, isUndefined), source: omitBy(card.metadata.source, isUndefined) }
        }))
        .orderBy((card: w.CardInStore) => card.metadata.updated)
        .value() as any as w.CardInStore[];

      console.log(cards);
      fb.database().ref('cards').set(fromPairs(cards.map((c) => [c.id || id(), c])));
    });
};
```
(with appropriate permissions)