### PR TITLE
Allow getHex() to correctly handle objects that were just destroyed (fix #1361)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:types": "tsc --skipLibCheck --noEmit",
     "test:integration": "jest integration",
     "test:integration:watch": "yarn test:integration --watch",
-    "test:unit": "jest --testPathIgnorePatterns integration",
+    "test:unit": "jest --testPathIgnorePatterns integration --testPathPattern",
     "test:unit:coverage": "yarn test:unit --coverage",
     "test:unit:watch": "yarn test:unit --watch"
   },

--- a/src/common/components/cards/CardCreationForm.tsx
+++ b/src/common/components/cards/CardCreationForm.tsx
@@ -387,7 +387,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
 
   private handleClickRandomize = () => {
     if (this.props.isReadonly) { return; }
-    const example = exampleStore.getExample(this.parserMode);
+    const example: string | null = exampleStore.getExample(this.parserMode);
     if (example) {
       this.onUpdateText(example, this.props.type, true);
     }

--- a/src/common/store/defaultGameState.ts
+++ b/src/common/store/defaultGameState.ts
@@ -78,6 +78,7 @@ const defaultGameState: w.GameState = {
   usernames: { blue: '', orange: '' },
   actionLog: [],
   attack: null,
+  objectsDestroyedThisTurn: {},
   memory: {},
   sfxQueue: [],
   eventQueue: [],

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -211,6 +211,7 @@ export interface GameState {
   eventQueue: CardInGame[]
   gameFormat: Format
   memory: Record<string, any>
+  objectsDestroyedThisTurn: Record<string, HexId>  // object id -> last hex id
   options: GameOptions
   player: PlayerColor | 'neither'
   players: PerPlayer<PlayerInGameState>

--- a/src/common/util/CardTextExampleStore.ts
+++ b/src/common/util/CardTextExampleStore.ts
@@ -10,11 +10,15 @@ export default class CardTextExampleStore {
     object: []
   };
 
-  public getExample = (mode: w.ParserMode): string => {
+  public getExample = (mode: w.ParserMode): string | null => {
     const examples = this.examples[mode];
-    const idx = random(0, examples.length - 1);
-    const example = pullAt(examples, idx)[0];
-    return `${example}.`;
+    if (examples.length > 0) {
+      const idx = random(0, examples.length - 1);
+      const example = pullAt(examples, idx)[0];
+      return `${example}.`;
+    } else {
+      return null;
+    }
   }
 
   public loadExamples = (sentences: string[], numToTry: number): Promise<any> => {

--- a/src/common/util/game.ts
+++ b/src/common/util/game.ts
@@ -193,7 +193,7 @@ export function allHexIds(): w.HexId[] {
 }
 
 export function getHex(state: w.GameState, object: w.Object): w.HexId | undefined {
-  return findKey(allObjectsOnBoard(state), ['id', object.id]);
+  return findKey(allObjectsOnBoard(state), ['id', object.id]) || state.objectsDestroyedThisTurn[object.id];
 }
 
 export function getAdjacentHexes(hex: Hex): Hex[] {
@@ -413,6 +413,7 @@ function endTurn(state: w.GameState): w.GameState {
   state = triggerEvent(state, 'endOfTurn', {player: true});
   state = checkVictoryConditions(state);
   state.currentTurn = opponentName(state);
+  state.objectsDestroyedThisTurn = {};
 
   return state;
 }
@@ -581,6 +582,8 @@ export function removeObjectFromBoard(state: w.GameState, object: w.Object, hex:
       const targets: w.Targetable[] = ability.currentTargets!.entries;
       targets.forEach(ability.unapply);
     });
+
+  state.objectsDestroyedThisTurn[object.id] = hex;
 
   state = applyAbilities(state);
   state = checkVictoryConditions(state);

--- a/src/common/vocabulary/targets.ts
+++ b/src/common/vocabulary/targets.ts
@@ -21,6 +21,7 @@ export default function targets(state: w.GameState, currentObject: w.Object | nu
   // Currently salient object
   // Note: currentObject has higher salience than state.it .
   //       (This resolves the bug where robots' Haste ability would be triggered by other robots being played.)
+  /* eslint-disable jest/no-disabled-tests */  // eslint gets confused because of the it() function
   function it(): w.ObjectCollection | w.CardInHandCollection {
     if (currentObject) {
       return { type: 'objects', entries: [currentObject] } as w.ObjectCollection;
@@ -124,7 +125,7 @@ export default function targets(state: w.GameState, currentObject: w.Object | nu
       }
     },
 
-    controllerOf: (objects: w.ObjectCollection): w.PlayerCollection => 
+    controllerOf: (objects: w.ObjectCollection): w.PlayerCollection =>
       // Assume that only one object is ever passed in here.
        ({
         type: 'players',
@@ -132,7 +133,7 @@ export default function targets(state: w.GameState, currentObject: w.Object | nu
       })
     ,
 
-    copyOf: (collection: w.ObjectCollection): w.CardInHandCollection => 
+    copyOf: (collection: w.ObjectCollection): w.CardInHandCollection =>
       // Assume that exactly one object is ever passed in here.
       // TODO Also support copyOf on CardInHandCollection.
        ({
@@ -158,7 +159,7 @@ export default function targets(state: w.GameState, currentObject: w.Object | nu
     },
 
     // Currently salient object.
-    it: (): w.ObjectCollection | w.CardInHandCollection => 
+    it: (): w.ObjectCollection | w.CardInHandCollection =>
       /* console.log({
         it: state.it ? state.it.name || state.it.card.name : null,
         currentObject: currentObject ? currentObject.name || currentObject.card.name : null

--- a/test/vocabulary/targets.spec.ts
+++ b/test/vocabulary/targets.spec.ts
@@ -22,9 +22,21 @@ describe('[vocabulary.targets]', () => {
     });
   });
 
-  // eslint-disable-next-line lodash/prefer-noop
-  xdescribe('that', () => {
+  describe('that', () => {
     // TODO: "Whenever this robot attacks a robot, destroy that robot."
+
+    it('handles situations where a targeted object no longer exists', () => {
+      let state = getDefaultState();
+      state = playObject(state, 'orange', cards.oneBotCard, '3,-1,-2');
+      state = playObject(state, 'orange', cards.oneBotCard, '2,-1,-3');
+
+      const fragGrenadeCard = event(
+        'Deal 3 damage to a robot, then deal 3 damage to all robots adjacent to that robot.',
+        "(function () { (function () { actions['dealDamage'](targets['choose'](objectsMatchingConditions('robot', [])), 3); })(); (function () { actions['dealDamage'](objectsMatchingConditions('robot', [conditions['adjacentTo'](targets['that']())]), 3); })(); })"
+      );
+      state = playEvent(state, 'blue', fragGrenadeCard, [{ hex: '3,-1,-2' }]);
+      expect(objectsOnBoardOfType(state, TYPE_ROBOT)).toEqual({});
+    });
   });
 
   describe('they', () => {


### PR DESCRIPTION
As a drive-by, fix an edge case where `CardTextExampleStore` didn't work right on a fresh firebase instance.