### PR TITLE
Simple community page showing most active players (close #1365)

### DIFF
--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -5,6 +5,9 @@
         ".write": "auth != null && auth.uid === $uid",
         ".indexOn": ["statistics/numCardsCreated", "statistics/numDecksCreated", "statistics/numSetsCreated", "statistics/numGamesPlayed"],
         "info": {
+          "uid": {
+            ".read": "true"
+          },
           "displayName": {
             ".read": "true"
           }

--- a/firebaseRules.json
+++ b/firebaseRules.json
@@ -1,22 +1,11 @@
 {
   "rules": {
     "users": {
+      ".read": "true",
       "$uid": {
         ".write": "auth != null && auth.uid === $uid",
         ".indexOn": ["statistics/numCardsCreated", "statistics/numDecksCreated", "statistics/numSetsCreated", "statistics/numGamesPlayed"],
-        "info": {
-          "uid": {
-            ".read": "true"
-          },
-          "displayName": {
-            ".read": "true"
-          }
-        },
-        "achievements": {
-          ".read": "true"
-        },
         "statistics": {
-          ".read": "true",
           ".write": "true"
         }
       }

--- a/src/common/components/NavMenu.tsx
+++ b/src/common/components/NavMenu.tsx
@@ -40,6 +40,7 @@ export default class NavMenu extends React.Component<NavMenuProps> {
         {this.renderLink('/decks', 'Decks', 'view_list')}
         {this.renderLink('/sets', 'Sets', 'layers')}
         {this.renderLink('/play', 'Play', 'videogame_asset')}
+        {this.renderLink('/community', 'Community', 'people')}
         {this.renderLink('/about', 'About', 'info_outline')}
         {canExpand && this.renderExpandCollapseButton()}
       </Drawer>

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -1,11 +1,10 @@
 import { History } from 'history';
-import { range, uniqBy } from 'lodash';
-import { filter, flow, orderBy, slice } from 'lodash/fp';
+import { range } from 'lodash';
 import * as React from 'react';
 import Carousel, { ResponsiveObject } from 'react-slick';
 
 import * as w from '../../types';
-import { getCards } from '../../util/firebase';
+import { mostRecentCards } from '../../util/firebase';
 import Card from '../card/Card';
 
 import CardProvenanceDescription from './CardProvenanceDescription';
@@ -98,21 +97,7 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
   }
 
   private initializeCarousel = async (userId?: string) => {
-    const cards = await getCards(userId || null);
-    let recentCards: w.CardInStore[] = flow(
-      (cs: w.CardInStore[]) => uniqBy(cs, 'name'),
-      filter((c: w.CardInStore) =>  // Filter out all of the following from carousels:
-        !!c.text  // cards without text (uninteresting)
-          && !!c.metadata.updated  // cards without timestamp (can't order them)
-          && c.metadata.source.type === 'user'  // built-in cards
-          && !c.metadata.isPrivate  // private cards
-          && !c.metadata.duplicatedFrom  // duplicated cards
-          && !c.metadata.importedFromJson  // cards imported from JSON
-          && (c.metadata.source.uid === c.metadata.ownerId)  // cards imported from other players' collections
-      ),
-      orderBy((c: w.CardInStore) => c.metadata.updated, ['desc']),
-      slice(0, 15)
-    )(cards) as w.CardInStore[];
+    let recentCards = await mostRecentCards(userId, 15);
 
     if (recentCards.length < RecentCardsCarousel.MAX_CARDS_TO_SHOW && recentCards.length > 0) {
       while (recentCards.length < RecentCardsCarousel.MAX_CARDS_TO_SHOW) {

--- a/src/common/components/cards/RecentCardsCarousel.tsx
+++ b/src/common/components/cards/RecentCardsCarousel.tsx
@@ -97,7 +97,7 @@ export default class RecentCardsCarousel extends React.Component<RecentCardsCaro
   }
 
   private initializeCarousel = async (userId?: string) => {
-    let recentCards = await mostRecentCards(userId, 15);
+    let recentCards = await mostRecentCards(userId || null, 15);
 
     if (recentCards.length < RecentCardsCarousel.MAX_CARDS_TO_SHOW && recentCards.length > 0) {
       while (recentCards.length < RecentCardsCarousel.MAX_CARDS_TO_SHOW) {

--- a/src/common/components/users/CommunityUser.tsx
+++ b/src/common/components/users/CommunityUser.tsx
@@ -3,9 +3,9 @@ import { DoubleBounce } from 'better-react-spinkit';
 import { History } from 'history';
 import * as React from 'react';
 
-import * as w from '../../types';
 import Card from '../card/Card';
 import ProfileLink from '../users/ProfileLink';
+import * as w from '../../types';
 import { mostRecentCards } from '../../util/firebase';
 
 interface CommunityUserProps {

--- a/src/common/components/users/CommunityUser.tsx
+++ b/src/common/components/users/CommunityUser.tsx
@@ -1,0 +1,69 @@
+import Paper from '@material-ui/core/Paper';
+import { DoubleBounce } from 'better-react-spinkit';
+import { History } from 'history';
+import * as React from 'react';
+
+import * as w from '../../types';
+import Card from '../card/Card';
+import ProfileLink from '../users/ProfileLink';
+import { mostRecentCards } from '../../util/firebase';
+
+interface CommunityUserProps {
+  user: w.User
+  history: History
+}
+
+interface CommunityUserState {
+  mostRecentCard?: w.CardInStore | null
+}
+
+export default class CommunityUser extends React.Component<CommunityUserProps, CommunityUserState> {
+  public state: CommunityUserState = {};
+
+  public async componentDidMount(): Promise<void> {
+    await this.loadMostRecentCard();
+  }
+
+  public render(): JSX.Element {
+    const { user } = this.props;
+    const card = this.state.mostRecentCard;
+    const info = user.info!;
+    const statistics = user.statistics!;
+
+    return (
+      <Paper key={info.uid} style={{ width: 280, marginRight: 20, marginBottom: 20, padding: 10 }}>
+        <div style={{ float: 'left', width: 130 }}>
+          <ProfileLink uid={info.uid} username={info.displayName!} style={{ fontWeight: 'bold', fontSize: '1.2em' }} />
+          <p><b>{statistics['cardsCreated'] || 0}</b> cards created</p>
+          <p><b>{statistics['decksCreated'] || 0}</b> decks created</p>
+          <p><b>{statistics['setsCreated'] || 0}</b> sets created</p>
+          <p><b>{statistics['gamesPlayed'] || 0}</b> games played</p>
+        </div>
+        {card !== null && (
+          <div style={{ float: 'right', width: 130 }}>
+            {
+              card
+                ? Card.fromObj(card, { scale: 0.8, onCardClick: () => { this.handleClickCard(card); }})
+                : <div style={{ margin: '80px 40px' }}><DoubleBounce size={50} /></div>
+            }
+            <div style={{ textAlign: 'center', color: '#999', fontSize: '0.7em' }}>Most recent card</div>
+          </div>
+        )}
+
+      </Paper>
+    );
+  }
+
+  private loadMostRecentCard = async (): Promise<void> => {
+    const uid = this.props.user.info!.uid;
+    const cards = await mostRecentCards(uid, 1);
+
+    if (cards.length > 0) {
+      this.setState({ mostRecentCard: cards[0] || null });
+    }
+  }
+
+  private handleClickCard = (card: w.CardInStore) => {
+    this.props.history.push(`/card/${card.id}`, { card });
+  }
+}

--- a/src/common/containers/App.tsx
+++ b/src/common/containers/App.tsx
@@ -25,6 +25,7 @@ import { getCards, getDecks, getSets, onLogin, onLogout } from '../util/firebase
 
 import About from './About';
 import Collection from './Collection';
+import Community from './Community';
 import Creator from './Creator';
 import Deck from './Deck';
 import Decks from './Decks';
@@ -189,6 +190,7 @@ class App extends React.Component<AppProps, AppState> {
             <Route path="/sets/:setId" component={Set as any} />
             <Route path="/sets" component={Sets as any} />
             <Route path="/play" component={Play} />
+            <Route path="/community" component={Community} />
             <Route path="/about" component={About} />
             <Route path="/profile/:userId" component={Profile} />
             <Route render={this.redirectToRoot} />

--- a/src/common/containers/Community.tsx
+++ b/src/common/containers/Community.tsx
@@ -5,21 +5,18 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { RouteComponentProps, withRouter } from 'react-router';
 
-import Card from '../components/card/Card';
 import Title from '../components/Title';
-import ProfileLink from '../components/users/ProfileLink';
+import CommunityUser from '../components/users/CommunityUser';
 import * as w from '../types';
-import { getUsers, mostRecentCards } from '../util/firebase';
+import { getUsers } from '../util/firebase';
 
 interface CommunityState {
   users: w.User[]
-  mostRecentCardByUserId: Record<string, w.CardInStore>
 }
 
 class Community extends React.Component<RouteComponentProps, CommunityState> {
   public state: CommunityState = {
-    users: [],
-    mostRecentCardByUserId: {}
+    users: []
   };
 
   public async componentDidMount(): Promise<void> {
@@ -27,6 +24,7 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
   }
 
   public render(): JSX.Element {
+    const { history } = this.props;
     const { users } = this.state;
 
     return (
@@ -56,37 +54,12 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
               justifyContent: 'flex-start'
             }}
           >
-            {users.map(this.renderUser)}
+            {users.map((user, i) =>
+              <CommunityUser key={i} user={user} history={history} />
+            )}
           </div>
         </div>
       </div>
-    );
-  }
-
-  private renderUser = (user: w.User): JSX.Element => {
-    const { mostRecentCardByUserId } = this.state;
-
-    const info = user.info!;
-    const statistics = user.statistics!;
-    const card: w.CardInStore | undefined = mostRecentCardByUserId[info.uid];
-
-    return (
-      <Paper key={info.uid} style={{ width: 280, marginRight: 20, marginBottom: 20, padding: 10 }}>
-        <div style={{ float: 'left', width: 130 }}>
-          <ProfileLink uid={info.uid} username={info.displayName!} style={{ fontWeight: 'bold', fontSize: '1.2em' }} />
-          <p><b>{statistics['cardsCreated'] || 0}</b> cards created</p>
-          <p><b>{statistics['decksCreated'] || 0}</b> decks created</p>
-          <p><b>{statistics['setsCreated'] || 0}</b> sets created</p>
-          <p><b>{statistics['gamesPlayed'] || 0}</b> games played</p>
-        </div>
-        {card && (
-          <div style={{ float: 'right', width: 130 }}>
-            {Card.fromObj(card, { scale: 0.8, onCardClick: () => { this.handleClickCard(card); }})}
-            <div style={{ textAlign: 'center', color: '#999', fontSize: '0.7em' }}>Most recent card</div>
-          </div>
-        )}
-
-      </Paper>
     );
   }
 
@@ -98,24 +71,7 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
       slice(0, 10)
     )(allUsers);
 
-    this.setState({ users }, () => {
-      users.forEach(this.loadCardForUser);
-    });
-  }
-
-  private loadCardForUser = async (user: w.User): Promise<void> => {
-    const uid = user.info!.uid;
-    const cards = await mostRecentCards(uid, 1);
-
-    if (cards.length > 0) {
-      this.setState(({ mostRecentCardByUserId }) => ({
-        mostRecentCardByUserId: { ...mostRecentCardByUserId, [uid]: cards[0] }
-      }));
-    }
-  }
-
-  private handleClickCard = (card: w.CardInStore) => {
-    this.props.history.push(`/card/${card.id}`, { card });
+    this.setState({ users });
   }
 }
 

--- a/src/common/containers/Community.tsx
+++ b/src/common/containers/Community.tsx
@@ -1,6 +1,6 @@
-import { fromPairs, sum } from 'lodash';
+import { sum } from 'lodash';
 import { filter, flow, orderBy, slice } from 'lodash/fp';
-import { Paper } from 'material-ui';
+import Paper from '@material-ui/core/Paper';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { RouteComponentProps, withRouter } from 'react-router';
@@ -49,7 +49,14 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
           </Paper>
         </div>
 
-        <div>
+        <div
+          style={{
+            margin: 20,
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'flex-start'
+          }}
+        >
           {users.map(this.renderUser)}
         </div>
       </div>
@@ -64,18 +71,18 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
     const card: w.CardInStore | undefined = mostRecentCardByUserId[info.uid];
 
     return (
-      <Paper key={info.uid} style={{ float: 'left', width: 400, margin: 20, padding: 10 }}>
-        <div style={{ float: 'left', width: '48%' }}>
-          <ProfileLink uid={info.uid} username={info.displayName!} style={{ fontWeight: 'bold' }} />
-          <p>{statistics['cardsCreated'] || 0} cards created</p>
-          <p>{statistics['decksCreated'] || 0} decks created</p>
-          <p>{statistics['setsCreated'] || 0} sets created</p>
-          <p>{statistics['gamesPlayed'] || 0} games played</p>
+      <Paper key={info.uid} style={{ width: 280, marginRight: 20, marginBottom: 20, padding: 10 }}>
+        <div style={{ float: 'left', width: 130 }}>
+          <ProfileLink uid={info.uid} username={info.displayName!} style={{ fontWeight: 'bold', fontSize: '1.2em' }} />
+          <p><b>{statistics['cardsCreated'] || 0}</b> cards created</p>
+          <p><b>{statistics['decksCreated'] || 0}</b> decks created</p>
+          <p><b>{statistics['setsCreated'] || 0}</b> sets created</p>
+          <p><b>{statistics['gamesPlayed'] || 0}</b> games played</p>
         </div>
         {card && (
-          <div style={{ float: 'right', width: '48%' }}>
-            {Card.fromObj(card, { onCardClick: () => { this.handleClickCard(card); }})}
-            <span style={{ color: '#999', fontSize: '0.85em' }}>Most recent card created</span>
+          <div style={{ float: 'right', width: 130 }}>
+            {Card.fromObj(card, { scale: 0.8, onCardClick: () => { this.handleClickCard(card); }})}
+            <div style={{ textAlign: 'center', color: '#999', fontSize: '0.7em' }}>Most recent card</div>
           </div>
         )}
 

--- a/src/common/containers/Community.tsx
+++ b/src/common/containers/Community.tsx
@@ -1,0 +1,115 @@
+import { fromPairs, sum } from 'lodash';
+import { filter, flow, orderBy, slice } from 'lodash/fp';
+import { Paper } from 'material-ui';
+import * as React from 'react';
+import Helmet from 'react-helmet';
+import { RouteComponentProps, withRouter } from 'react-router';
+
+import Card from '../components/card/Card';
+import Title from '../components/Title';
+import ProfileLink from '../components/users/ProfileLink';
+import * as w from '../types';
+import { getUsers, mostRecentCards } from '../util/firebase';
+
+interface CommunityState {
+  users: w.User[]
+  mostRecentCardByUserId: Record<string, w.CardInStore>
+}
+
+class Community extends React.Component<RouteComponentProps, CommunityState> {
+  public state: CommunityState = {
+    users: [],
+    mostRecentCardByUserId: {}
+  };
+
+  public async componentDidMount(): Promise<void> {
+    await this.loadData();
+  }
+
+  public render(): JSX.Element {
+    const { users } = this.state;
+
+    return (
+      <div>
+        <Helmet title="Community"/>
+        <Title text="Community" />
+
+        <div>
+          <Paper
+            style={{
+              display: 'inline-block',
+              marginLeft: 20,
+              marginTop: 20,
+              padding: '5px 15px',
+              fontSize: 20,
+              fontFamily: 'Carter One'
+            }}
+          >
+            Most active players
+          </Paper>
+        </div>
+
+        <div>
+          {users.map(this.renderUser)}
+        </div>
+      </div>
+    );
+  }
+
+  private renderUser = (user: w.User): JSX.Element => {
+    const { mostRecentCardByUserId } = this.state;
+
+    const info = user.info!;
+    const statistics = user.statistics!;
+    const card: w.CardInStore | undefined = mostRecentCardByUserId[info.uid];
+
+    return (
+      <Paper key={info.uid} style={{ float: 'left', width: 400, margin: 20, padding: 10 }}>
+        <div style={{ float: 'left', width: '48%' }}>
+          <ProfileLink uid={info.uid} username={info.displayName!} style={{ fontWeight: 'bold' }} />
+          <p>{statistics['cardsCreated'] || 0} cards created</p>
+          <p>{statistics['decksCreated'] || 0} decks created</p>
+          <p>{statistics['setsCreated'] || 0} sets created</p>
+          <p>{statistics['gamesPlayed'] || 0} games played</p>
+        </div>
+        {card && (
+          <div style={{ float: 'right', width: '48%' }}>
+            {Card.fromObj(card, { onCardClick: () => { this.handleClickCard(card); }})}
+            <span style={{ color: '#999', fontSize: '0.85em' }}>Most recent card created</span>
+          </div>
+        )}
+
+      </Paper>
+    );
+  }
+
+  private loadData = async (): Promise<void> => {
+    const allUsers = await getUsers();
+    const users: w.User[] = flow(
+      filter((u: w.User) => !!u.info && !!u.statistics && u.statistics['cardsCreated'] > 0),
+      orderBy((u: w.User) => sum(Object.values(u.statistics!)), 'desc'),
+      slice(0, 10)
+    )(allUsers);
+
+    this.setState({ users }, () => {
+      users.forEach(this.loadCardForUser);
+    });
+  }
+
+  private loadCardForUser = async (user: w.User): Promise<void> => {
+    const uid = user.info!.uid;
+    const cards = await mostRecentCards(uid, 1);
+
+    if (cards.length > 0) {
+      this.setState(({ mostRecentCardByUserId }) => ({
+        mostRecentCardByUserId: { ...mostRecentCardByUserId, [uid]: cards[0] }
+      }));
+    }
+  }
+
+  private handleClickCard = (card: w.CardInStore) => {
+    this.props.history.push(`/card/${card.id}`, { card });
+  }
+}
+
+export default withRouter(Community);

--- a/src/common/containers/Community.tsx
+++ b/src/common/containers/Community.tsx
@@ -34,30 +34,30 @@ class Community extends React.Component<RouteComponentProps, CommunityState> {
         <Helmet title="Community"/>
         <Title text="Community" />
 
-        <div>
-          <Paper
+        <div style={{ margin: 20 }}>
+          <div>
+            <Paper
+              style={{
+                display: 'inline-block',
+                padding: '5px 15px',
+                fontSize: 20,
+                fontFamily: 'Carter One'
+              }}
+            >
+              Most active players
+            </Paper>
+          </div>
+
+          <div
             style={{
-              display: 'inline-block',
-              marginLeft: 20,
               marginTop: 20,
-              padding: '5px 15px',
-              fontSize: 20,
-              fontFamily: 'Carter One'
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'flex-start'
             }}
           >
-            Most active players
-          </Paper>
-        </div>
-
-        <div
-          style={{
-            margin: 20,
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'flex-start'
-          }}
-        >
-          {users.map(this.renderUser)}
+            {users.map(this.renderUser)}
+          </div>
         </div>
       </div>
     );

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -168,6 +168,12 @@ export interface EventTarget {
   undergoer?: _Object
 }
 
+export interface User {
+  info?: fb.UserInfo
+  achievements?: Record<string, boolean>
+  statistics?: Record<string, number>
+}
+
 // Redux store types
 
 export interface State {

--- a/src/common/util/firebase.ts
+++ b/src/common/util/firebase.ts
@@ -179,8 +179,8 @@ export async function getCardById(cardId: string): Promise<w.CardInStore> {
   return snapshot.val() as w.CardInStore;
 }
 
-export async function mostRecentCards(uid: w.UserId | undefined, limit: number): Promise<w.CardInStore[]> {
-  const cards = await getCards(uid || null);
+export async function mostRecentCards(uid: w.UserId | null, limit: number): Promise<w.CardInStore[]> {
+  const cards = await getCards(uid);
 
   return flow(
     uniqBy((c: w.CardInStore) => c.name),


### PR DESCRIPTION
For now the page just displays most active players (up to 10). In the future we could also display popular cards/decks/sets and other content?

The styling is still a little meh, I could probably use your help on this @jacobnisnevich .

![image](https://user-images.githubusercontent.com/415965/102166763-b8d9a600-3e41-11eb-8999-d9ef57df92c3.png)

