### PR TITLE
Fix dictionary dialog (fix #1426)

### DIFF
--- a/src/common/components/help/DictionaryDialog.tsx
+++ b/src/common/components/help/DictionaryDialog.tsx
@@ -28,6 +28,7 @@ type TabTerm = 'dictionaryTerm' | 'thesaurusTerm' | 'keywordsTerm';
 const DICTIONARY_TABS: DictionaryTab[] = ['dictionary', 'thesaurus', 'keywords'];
 
 interface DictionaryState {
+  currentPath: string
   dictionary: w.Dictionary
   tabIdx: number
   dictionaryTerm: string | null
@@ -39,6 +40,7 @@ interface DictionaryState {
 
 export default class DictionaryDialog extends React.Component<{ history: History }, DictionaryState> {
   public state: DictionaryState = {
+    currentPath: '',
     dictionary: {
       definitions: {},
       examplesByToken: {},
@@ -64,12 +66,19 @@ export default class DictionaryDialog extends React.Component<{ history: History
     }));
   }
 
-  public shouldComponentUpdate(_nextProps: { history: History }, nextState: DictionaryState): boolean {
-    return !isEqual(nextState, this.state);
+  public shouldComponentUpdate(nextProps: { history: History }, nextState: DictionaryState): boolean {
+    return (
+      !isEqual(nextState, this.state) ||
+        // can't do `!== this.props.history.location.pathname` because History gets mutated by react-router -AN
+        (nextProps.history.location.pathname !== this.state.currentPath)
+    );
   }
 
   public componentDidUpdate(): void {
     const { tabIdx } = this.state;
+
+    this.setState({ currentPath: this.props.history.location.pathname });
+
     if (tabIdx === 0) {
       markAchievement('openedDictionary');
     } else if (tabIdx === 1) {


### PR DESCRIPTION
DictionaryDialog was not opening/closing correctly because `shouldComponentUpdate` wasn't triggering on location changes. (We might just want to rethink how our `RouterDialog`s work in general, but this should fix it for now.)