### PR TITLE
Improved gameplay animations, including new animation when objects take damage

### DIFF
--- a/src/common/components/game/Board.tsx
+++ b/src/common/components/game/Board.tsx
@@ -87,7 +87,8 @@ export default class Board extends React.Component<BoardProps, BoardState> {
         movesUsed: (piece && getAttribute(piece, 'speed') !== undefined) ? (getAttribute(piece, 'speed')! - movesLeft(piece as w.Robot)) : undefined,
         movesAvailable: (piece && getAttribute(piece, 'speed') !== undefined) ? movesLeft(piece as w.Robot) : undefined
       },
-      attacking: (attack && attack.from === hex && !attack.retract) ? attack.to : null
+      attacking: (attack && attack.from === hex && !attack.retract) ? attack.to : null,
+      isDamaged: !!piece.tookDamageThisTurn
     }));
   }
 

--- a/src/common/components/game/EventAnimation.tsx
+++ b/src/common/components/game/EventAnimation.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
 import { EVENT_ANIMATION_TIME_MS, EVENT_ANIMATION_Z_INDEX } from '../../constants';
 import * as w from '../../types';
@@ -46,15 +45,9 @@ export default class EventAnimation extends React.Component<EventAnimationProps,
             zIndex: EVENT_ANIMATION_Z_INDEX
           }}
         >
-          <TransitionGroup>
-            <CSSTransition
-              appear
-              classNames={`event-animation-${this.props.currentTurn}`}
-              timeout={500}
-            >
-              {this.renderEvent()}
-            </CSSTransition>
-          </TransitionGroup>
+          <div className={`event-animation-${this.props.currentTurn}`}>
+            {this.renderEvent()}
+          </div>
         </div>
       );
     } else {

--- a/src/common/components/hexgrid/HexGrid.tsx
+++ b/src/common/components/hexgrid/HexGrid.tsx
@@ -99,7 +99,7 @@ export default class HexGrid extends React.Component<HexShapeProps> {
               <CSSTransition
                 key={piece.id}
                 classNames="hex-piece"
-                timeout={ANIMATION_TIME_MS}
+                timeout={{ enter: 0, exit: ANIMATION_TIME_MS }}
               >
                 <HexPiece
                   hex={HexUtils.IDToHex(hex)}

--- a/src/common/components/hexgrid/types.d.ts
+++ b/src/common/components/hexgrid/types.d.ts
@@ -39,4 +39,5 @@ export interface PieceOnBoard {
     movesAvailable?: number
   }
   attacking: w.HexId | null
+  isDamaged: boolean
 }

--- a/src/common/containers/Play.tsx
+++ b/src/common/containers/Play.tsx
@@ -92,7 +92,7 @@ export const urlForGameMode = (mode: string, format: w.BuiltInFormat | null = nu
 
 export class Play extends React.Component<PlayProps> {
   get rightMenu(): React.ReactNode {
-    if (this.props.started) {
+    if (this.props.started || this.urlMatchesGameMode('sandbox')) {
       return null;  // If a game is in progress, it will render its own <Chat>.
     } else {
       return (
@@ -159,6 +159,8 @@ export class Play extends React.Component<PlayProps> {
   private navigateToMode = (mode: string, format: w.BuiltInFormat | null = null, deck: w.DeckInStore | null = null) => {
     this.props.history.push(urlForGameMode(mode, format, deck));
   }
+
+  private urlMatchesGameMode = (mode: string) => this.props.history.location.pathname.startsWith(urlForGameMode(mode));
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Play));

--- a/src/common/reducers/game.ts
+++ b/src/common/reducers/game.ts
@@ -7,7 +7,7 @@ import defaultState from '../store/defaultGameState';
 import * as w from '../types';
 import { replaceCardsInPlayerState } from '../util/cards';
 import { id } from '../util/common';
-import { triggerSound } from '../util/game';
+import { cleanUpAnimations, triggerSound } from '../util/game';
 
 import g from './handlers/game';
 
@@ -35,11 +35,11 @@ export function handleAction(
   oldState: State,
   { type, payload }: w.Action = { type: '' }
 ): State {
-  let state: State = {...oldState};
+  // First, clone state and clean up any currently running animation (e.g. objects turning red because they took damage).
+  let state: State = cleanUpAnimations({...oldState});
 
   if (!PURELY_VISUAL_ACTIONS.includes(type)) {
-    state = {...state,
-      actionId: id()};
+    state = {...state, actionId: id()};
   }
 
   switch (type) {

--- a/src/common/store/defaultGameState.ts
+++ b/src/common/store/defaultGameState.ts
@@ -44,7 +44,8 @@ function playerState(
         stats: {...coreCard.stats} as { health: number },
         movesMade: 0,
         triggers: [],
-        abilities: []
+        abilities: [],
+        tookDamageThisTurn: false
       }
     },
     selectedCard: null,

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -338,6 +338,7 @@ interface _Object { // eslint-disable-line @typescript-eslint/naming-convention
   attackedLastTurn?: boolean
   movedThisTurn?: boolean
   movedLastTurn?: boolean
+  tookDamageThisTurn?: boolean
   beingDestroyed?: boolean
   isDestroyed?: boolean
   mostRecentlyInCombatWith?: _Object

--- a/src/common/util/game.ts
+++ b/src/common/util/game.ts
@@ -397,6 +397,7 @@ function endTurn(state: w.GameState): w.GameState {
     movedThisTurn: false,
     attackedLastTurn: ('attackedThisTurn' in obj) ? obj.attackedThisTurn : undefined,
     movedLastTurn: ('movedThisTurn' in obj) ? obj.movedThisTurn : undefined,
+    tookDamageThisTurn: false,
     mostRecentlyInCombatWith: undefined,
 
     abilities: obj.abilities ? compact(obj.abilities.map(decrementDuration) as w.PassiveAbility[]) : [],
@@ -507,6 +508,7 @@ export function dealDamageToObjectAtHex(state: w.GameState, amount: number, hex:
 
   if (!object.beingDestroyed) {
     object.stats.health -= amount;
+    object.tookDamageThisTurn = true;
     state = logAction(state, null, `|${object.card.name}| received ${amount} damage`, {[object.card.name]: object.card});
     state = triggerEvent(state, 'afterDamageReceived', {object});
   }
@@ -587,6 +589,14 @@ export function removeObjectFromBoard(state: w.GameState, object: w.Object, hex:
 
   state = applyAbilities(state);
   state = checkVictoryConditions(state);
+  return state;
+}
+
+export function cleanUpAnimations(state: w.GameState): w.GameState {
+  const cleanup = (obj: w.Object): w.Object => ({ ...obj, tookDamageThisTurn: false });
+
+  state.players['blue'].objectsOnBoard = mapValues(state.players['blue'].objectsOnBoard, cleanup);
+  state.players['blue'].objectsOnBoard = mapValues(state.players['blue'].objectsOnBoard, cleanup);
   return state;
 }
 

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -14,12 +14,19 @@
   transition: background-color 500ms ease-in-out;
 }
 
-.hex-piece-enter {
-  opacity: 0;
-}
-.hex-piece-enter-active {
+.hex-piece {
   opacity: 1;
+  animation: FadeIn 400ms ease-in-out;
 }
+.hex-piece.kernel {
+  opacity: 1;
+  animation: FadeIn 1200ms ease-in-out;
+}
+@keyframes FadeIn {
+  0% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
 .hex-piece-exit {
   opacity: 1;
 }
@@ -27,15 +34,22 @@
   opacity: 0;
 }
 
-.event-animation-orange-appear {
-  transform: translateY(500%);
-}
-.event-animation-blue-appear {
-  transform: translateY(-500%);
-}
-.event-animation-orange-appear-active, .event-animation-blue-appear-active {
+.event-animation-orange {
   transform: translateY(0%);
-  transition: transform 500ms ease-in-out;
+  animation: AppearFromBottom 500ms ease-in-out;
+}
+@keyframes AppearFromBottom {
+  0% { transform: translateY(500%); }
+  100% { transform: translateY(0%); }
+}
+
+.event-animation-blue {
+  transform: translateY(0%);
+  animation: AppearFromTop 500ms ease-in-out;
+}
+@keyframes AppearFromTop {
+  0% { transform: translateY(-500%); }
+  100% { transform: translateY(0%); }
 }
 
 .new-here-robot {
@@ -45,13 +59,11 @@
   right: -30px;
   cursor: pointer;
 }
-
 .new-here-robot:hover {
   animation: none;
   right: -24px;
   top: 114px;
 }
-
 @keyframes SlowShake {
   0%, 40% {
     right: -30px;
@@ -61,4 +73,23 @@
     right: -38px;
     top: 128px;
   }
+}
+
+.piece-damage {
+  animation: FadeToWhiteAndBack 1.7s linear;
+  filter: brightness(1);
+}
+@keyframes FadeToWhiteAndBack {
+  0%, 100% { filter: brightness(1); }
+  30%, 60% { filter: brightness(10); }
+}
+
+.piece-tint-damage {
+  animation: FadeInThenOut 1.7s linear;
+  fill: red;
+  opacity: 0;
+}
+@keyframes FadeInThenOut {
+  0%, 100% { opacity: 0; }
+  30%, 60% { opacity: 0.7; }
 }

--- a/test/components/Board.spec.js
+++ b/test/components/Board.spec.js
@@ -36,7 +36,8 @@ describe('Board component', () => {
           'health': STARTING_PLAYER_HEALTH
         },
         'type': TYPE_CORE,
-        'attacking': null
+        'attacking': null,
+        isDamaged: false
       },
       '3,0,-3': {
         'id': 'orangeCore',
@@ -48,7 +49,8 @@ describe('Board component', () => {
           'health': STARTING_PLAYER_HEALTH
         },
         'type': TYPE_CORE,
-        'attacking': null
+        'attacking': null,
+        isDamaged: false
       }
     });
   });

--- a/test/components/Board.spec.js
+++ b/test/components/Board.spec.js
@@ -37,7 +37,7 @@ describe('Board component', () => {
         },
         'type': TYPE_CORE,
         'attacking': null,
-        isDamaged: false
+        'isDamaged': false
       },
       '3,0,-3': {
         'id': 'orangeCore',
@@ -50,7 +50,7 @@ describe('Board component', () => {
         },
         'type': TYPE_CORE,
         'attacking': null,
-        isDamaged: false
+        'isDamaged': false
       }
     });
   });


### PR DESCRIPTION
[ fix #1336, fix #1415, fix #1443, fix #1444, fix #1445 ]

* animation (red tint + object fades to white) when objects take damage
* fix animations when playing objects and events (using raw CSS animations now instead of `CSSTransitionGroup`, which appears to have stop working for some things after we migrated to `react-transition-group 2.x`)
* make kernels fade in (a little more slowly than regular objects) at the start of the game
* fix a sandbox bug

Damage animation:
https://user-images.githubusercontent.com/415965/116018070-12bf5900-a5f6-11eb-9f3a-bd9d22531828.mov

