### PR TITLE
Many UX improvements in the card creator

### DIFF
--- a/src/common/components/cards/CardCreationForm.tsx
+++ b/src/common/components/cards/CardCreationForm.tsx
@@ -5,6 +5,7 @@ import { BigramProbs } from 'word-ngrams';
 
 import { CREATABLE_TYPES, TYPE_EVENT, TYPE_ROBOT, typeToString } from '../../constants';
 import * as w from '../../types';
+import { CardValidationResults } from '../../util/cards';
 import { saveReportedParseIssue } from '../../util/firebase';
 import Tooltip from '../Tooltip';
 import MustBeLoggedIn from '../users/MustBeLoggedIn';
@@ -28,10 +29,8 @@ interface CardCreationFormProps {
   isReadonly: boolean
   willCreateAnother: boolean
   submittedParseIssue: string | null
+  validationResults: CardValidationResults
   bigramProbs?: BigramProbs
-  isValid: boolean
-  parseErrors: string[]
-  validationErrors: Record<string, string | null>
 
   onSetName: (name: string) => void
   onSetType: (type: w.CardType) => void
@@ -91,7 +90,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
   }
 
   get hasTextError(): boolean {
-    return this.props.parseErrors.length > 0;
+    return this.props.validationResults.parseErrors.length > 0;
   }
 
   public componentDidMount(): void {
@@ -107,7 +106,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
   }
 
   public render(): JSX.Element {
-    const { isReadonly, isValid, validationErrors, willCreateAnother, onToggleWillCreateAnother } = this.props;
+    const { isReadonly, validationResults, willCreateAnother, onToggleWillCreateAnother } = this.props;
 
     return (
       <div>
@@ -118,8 +117,8 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
               value={this.props.name}
               label="Card Name"
               style={CardCreationForm.styles.leftCol}
-              error={!!validationErrors.name}
-              helperText={validationErrors.name}
+              error={!!validationResults.nameError}
+              helperText={validationResults.nameError}
               onChange={this.handleSetName}
             />
             <NumberField
@@ -133,7 +132,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                 style: { textAlign: 'center', marginLeft: 8, fontSize: 20 },
                 disableUnderline: true
               }}
-              errorText={validationErrors.cost}
+              errorText={validationResults.costError}
               onChange={this.setAttribute('cost')}
             />
           </div>
@@ -174,7 +173,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                 readonly={isReadonly}
                 text={this.props.text}
                 sentences={this.nonEmptySentences}
-                error={validationErrors.text}
+                error={validationResults.textError}
                 bigramProbs={this.props.bigramProbs}
                 onUpdateText={this.props.onUpdateText}
                 debounceMs={150}
@@ -221,7 +220,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                   variant="contained"
                   color="secondary"
                   fullWidth
-                  disabled={!isValid}
+                  disabled={!validationResults.isValid}
                   style={CardCreationForm.styles.saveButton}
                   onClick={this.handleSaveCard}
                 >
@@ -296,7 +295,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
           maxValue={opts.max || 10}
           style={CardCreationForm.styles.attribute}
           disabled={!enabled}
-          errorText={this.props.validationErrors[attribute]}
+          errorText={this.props.validationResults[`${attribute}Error` as 'attackError' | 'healthError' | 'speedError']}
           onChange={this.setAttribute(attribute)}
           inputProps={{
             startAdornment: (

--- a/src/common/components/cards/CardCreationForm.tsx
+++ b/src/common/components/cards/CardCreationForm.tsx
@@ -1,23 +1,16 @@
-import { Button, Checkbox, FormControl, FormControlLabel, Icon, InputAdornment, InputLabel, MenuItem, Paper, Select, Snackbar, TextField } from '@material-ui/core';
-import { capitalize, compact, isEmpty } from 'lodash';
+import { Button, Checkbox, FormControl, FormControlLabel, Icon, InputAdornment, InputLabel, MenuItem, Paper, Select, TextField } from '@material-ui/core';
+import { capitalize, isEmpty } from 'lodash';
 import * as React from 'react';
 import { BigramProbs } from 'word-ngrams';
 
 import { CREATABLE_TYPES, TYPE_EVENT, TYPE_ROBOT, typeToString } from '../../constants';
 import * as w from '../../types';
-import { getSentencesFromInput, requestParse } from '../../util/cards';
-import CardTextExampleStore from '../../util/CardTextExampleStore';
-import { ensureInRange } from '../../util/common';
-import { getCardTextCorpus, saveReportedParseIssue } from '../../util/firebase';
-import { prepareBigramProbs } from '../../util/language';
-import ButtonInRow from '../ButtonInRow';
+import { saveReportedParseIssue } from '../../util/firebase';
 import Tooltip from '../Tooltip';
 import MustBeLoggedIn from '../users/MustBeLoggedIn';
 
 import CardTextField from './CardTextField';
 import NumberField from './NumberField';
-
-const exampleStore = new CardTextExampleStore();
 
 interface CardCreationFormProps {
   id: string | null
@@ -34,10 +27,15 @@ interface CardCreationFormProps {
   isNewCard: boolean
   isReadonly: boolean
   willCreateAnother: boolean
+  submittedParseIssue: string | null
+  bigramProbs?: BigramProbs
+  isValid: boolean
+  parseErrors: string[]
+  validationErrors: Record<string, string | null>
 
   onSetName: (name: string) => void
   onSetType: (type: w.CardType) => void
-  onSetText: (text: string) => void
+  onUpdateText: (text: string, type?: w.CardType) => void
   onSetFlavorText: (flavorText: string) => void
   onSetAttribute: (attr: w.Attribute | 'cost', value: number) => void
   onParseComplete: (idx: number, sentence: string, result: w.ParseResult) => void
@@ -48,14 +46,7 @@ interface CardCreationFormProps {
   onToggleWillCreateAnother: () => void
 }
 
-interface CardCreationFormState {
-  bigramProbs?: BigramProbs
-  examplesLoaded: boolean
-  submittedParseIssue: string | null
-  submittedParseIssueConfirmationOpen: boolean
-}
-
-export default class CardCreationForm extends React.Component<CardCreationFormProps, CardCreationFormState> {
+export default class CardCreationForm extends React.Component<CardCreationFormProps> {
   private static styles: Record<string, React.CSSProperties> = {
     paper: {padding: 30, maxWidth: 800, margin: '0 auto'},
 
@@ -92,12 +83,6 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
     icon: {verticalAlign: 'middle', color: 'white'}
   };
 
-  public state: CardCreationFormState = {
-    examplesLoaded: false,
-    submittedParseIssue: null,
-    submittedParseIssueConfirmationOpen: false
-  };
-
   get robot(): boolean { return this.props.type === TYPE_ROBOT; }
   get event(): boolean { return this.props.type === TYPE_EVENT; }
 
@@ -105,91 +90,11 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
     return this.props.sentences.filter((s) => /\S/.test(s.sentence));
   }
 
-  get hasCardText(): boolean {
-    return this.nonEmptySentences.length > 0;
-  }
-
-  get fullParse(): string {
-    return compact(this.nonEmptySentences.map((s) => s.result.js)).join(' ');
-  }
-
-  get parserMode(): 'event' | 'object' {
-    return this.props.type === TYPE_EVENT ? 'event' : 'object';
-  }
-
-  get parseErrors(): string[] {
-    return compact(this.nonEmptySentences.map((s) => s.result.error)).map((error) =>
-      (`${error}.`)
-        .replace('..', '.')
-        .replace('Parser did not produce a valid expression', 'Parser error')
-    );
-  }
-
-  get nameError(): string | null {
-    if (!this.props.name || this.props.name === '[Unnamed]') {
-      return 'This card needs a name!';
-    }
-    return null;
-  }
-
-  get typeError(): string | null {
-    if (!CREATABLE_TYPES.includes(this.props.type)) {
-      return 'Invalid type.';
-    }
-    return null;
-  }
-
-  get costError(): string | null {
-    return ensureInRange('cost', this.props.cost, 0, 20);
-  }
-
-  get attackError(): string | null {
-    if (this.robot) {
-      return ensureInRange('attack', this.props.attack, 0, 10);
-    }
-    return null;
-  }
-
-  get healthError(): string | null {
-    if (!this.event) {
-      return ensureInRange('health', this.props.health, 1, 10);
-    }
-    return null;
-  }
-
-  get speedError(): string | null {
-    if (this.robot) {
-      return ensureInRange('speed', this.props.speed, 0, 3);
-    }
-    return null;
-  }
-
-  get textError(): string | null {
-    if (this.event && !this.hasCardText) {
-      return 'Action cards must have card text.';
-    } else if (this.parseErrors.length > 0) {
-      return this.parseErrors.join(' ');
-    } else if (this.nonEmptySentences.find((s) => !s.result.js)) {
-      return 'Sentences are still being parsed ...';
-    } else {
-      return null;
-    }
-  }
-
   get hasTextError(): boolean {
-    return this.parseErrors.length > 0;
-  }
-
-  get isValid(): boolean {
-    return !this.nameError && !this.typeError && !this.costError && !this.attackError &&
-      !this.healthError && !this.speedError && !this.textError;
+    return this.props.parseErrors.length > 0;
   }
 
   public componentDidMount(): void {
-    // Used by setStateIfMounted()
-    // See https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
-    (this as any)._isMounted = true;
-
     // Generate new spriteID on reload.
     if (!this.props.id) {
       this.props.onSpriteClick();
@@ -197,64 +102,15 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
 
     // This should only happen when we're loading an existing card (from Collection view).
     if (this.props.text !== '') {
-      this.onUpdateText(this.props.text, this.props.type);
+      this.props.onUpdateText(this.props.text, this.props.type);
     }
-
-    this.loadExampleCards();
-  }
-
-  public componentWillUnmount(): void {
-    (this as any)._isMounted = false;
   }
 
   public render(): JSX.Element {
-    const { isReadonly, willCreateAnother, onToggleWillCreateAnother } = this.props;
-    const { examplesLoaded, submittedParseIssue, submittedParseIssueConfirmationOpen } = this.state;
-
-    const FULL_WIDTH_PERCENT = 100;
-    const NUMBER_OF_BUTTONS = 4;
-    const MARGIN_PX = 15;
-
-    const buttonMaxWidth = FULL_WIDTH_PERCENT / NUMBER_OF_BUTTONS;
-    const buttonPadding = (MARGIN_PX * (NUMBER_OF_BUTTONS - 1)) / NUMBER_OF_BUTTONS;
+    const { isReadonly, isValid, validationErrors, willCreateAnother, onToggleWillCreateAnother } = this.props;
 
     return (
       <div>
-        <div style={{display: 'flex', justifyContent: 'center'}}>
-          <div style={{display: 'flex', justifyContent: 'space-between', marginBottom: MARGIN_PX, width: '100%', maxWidth: 860}}>
-            <ButtonInRow
-              label="Help"
-              icon="help_outline"
-              tooltip="Learn more about creating a card."
-              width={`calc(${buttonMaxWidth}% - ${buttonPadding}px)`}
-              onClick={this.handleClickHelp}
-            />
-            <ButtonInRow
-              label="Dictionary"
-              icon="book"
-              tooltip="Check out all of the terms and actions that the parser supports."
-              width={`calc(${buttonMaxWidth}% - ${buttonPadding}px)`}
-              onClick={this.handleClickDictionary}
-            />
-            <ButtonInRow
-              label="Randomize"
-              icon="refresh"
-              tooltip={`Generate random text for the card. ${examplesLoaded ? '' : '(Loading examples ...)'}`}
-              onClick={this.handleClickRandomize}
-              width={`calc(${buttonMaxWidth}% - ${buttonPadding}px)`}
-              disabled={!examplesLoaded || isReadonly}
-            />
-            <ButtonInRow
-              label="Test"
-              icon="videogame_asset"
-              tooltip="Test out this card in sandbox mode."
-              onClick={this.props.onTestCard}
-              width={`calc(${buttonMaxWidth}% - ${buttonPadding}px)`}
-              disabled={!this.isValid}
-            />
-          </div>
-        </div>
-
         <Paper style={CardCreationForm.styles.paper}>
           <div style={CardCreationForm.styles.section}>
             <TextField
@@ -262,8 +118,8 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
               value={this.props.name}
               label="Card Name"
               style={CardCreationForm.styles.leftCol}
-              error={!!this.nameError}
-              helperText={this.nameError}
+              error={!!validationErrors.name}
+              helperText={validationErrors.name}
               onChange={this.handleSetName}
             />
             <NumberField
@@ -277,7 +133,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                 style: { textAlign: 'center', marginLeft: 8, fontSize: 20 },
                 disableUnderline: true
               }}
-              errorText={this.costError}
+              errorText={validationErrors.cost}
               onChange={this.setAttribute('cost')}
             />
           </div>
@@ -318,9 +174,10 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                 readonly={isReadonly}
                 text={this.props.text}
                 sentences={this.nonEmptySentences}
-                error={this.textError}
-                bigramProbs={this.state?.bigramProbs}
-                onUpdateText={this.onUpdateText}
+                error={validationErrors.text}
+                bigramProbs={this.props.bigramProbs}
+                onUpdateText={this.props.onUpdateText}
+                debounceMs={150}
               />
             </div>
             <div style={CardCreationForm.styles.rightColContainer}>
@@ -329,24 +186,21 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                   variant="contained"
                   color="secondary"
                   style={{width: 40, minWidth: 40}}
-                  disabled={!this.hasTextError || !isEmpty(submittedParseIssue)}
+                  disabled={!this.hasTextError || !isEmpty(this.props.submittedParseIssue)}
                   onClick={this.handleClickReportParseIssue}
                 >
                   <Icon className="material-icons" style={CardCreationForm.styles.icon}>report_problem</Icon>
                 </Button>
               </Tooltip>
-              <Snackbar
-                open={submittedParseIssueConfirmationOpen}
-                message={`Reported issue parsing '${submittedParseIssue}'. Thanks for the feedback!`}
-                autoHideDuration={4000}
-                onClose={this.handleCloseReportParseIssueSnackbar}
-              />
             </div>
           </div>
 
           <div style={CardCreationForm.styles.section}>
             <TextField
+              multiline
+              variant="outlined"
               disabled={isReadonly}
+              rows={2}
               value={this.props.flavorText}
               label="Flavor Text (optional)"
               style={CardCreationForm.styles.fullWidth}
@@ -367,7 +221,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
                   variant="contained"
                   color="secondary"
                   fullWidth
-                  disabled={!this.isValid}
+                  disabled={!isValid}
                   style={CardCreationForm.styles.saveButton}
                   onClick={this.handleSaveCard}
                 >
@@ -409,23 +263,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
     const value: w.CardType = parseInt(e.target.value) as w.CardType;
     this.props.onSetType(value);
     // Re-parse card text because different card types now have different validations.
-    this.onUpdateText(this.props.text, value);
-  }
-
-  private handleClickHelp = () => {
-    this.props.onOpenDialog('help');
-  }
-
-  private handleClickDictionary = () => {
-    this.props.onOpenDialog('dictionary');
-  }
-
-  private handleClickRandomize = () => {
-    if (this.props.isReadonly) { return; }
-    const example: string | null = exampleStore.getExample(this.parserMode);
-    if (example) {
-      this.onUpdateText(example, this.props.type, true);
-    }
+    this.props.onUpdateText(this.props.text, value);
   }
 
   private handleClickReportParseIssue = () => {
@@ -438,32 +276,8 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
     }
   }
 
-  private handleCloseReportParseIssueSnackbar = () => {
-    this.setState({ submittedParseIssueConfirmationOpen: false });
-  }
-
   private handleSaveCard = () => {
     this.props.onAddToCollection(!this.props.willCreateAnother);
-  }
-
-  private onUpdateText = (text: string, cardType: w.CardType = this.props.type, dontIndex = false) => {
-    const parserMode = cardType === TYPE_EVENT ? 'event' : 'object';
-    const sentences = getSentencesFromInput(text);
-
-    this.props.onSetText(text);
-    this.setState({ submittedParseIssue: null });
-    requestParse(sentences, parserMode, this.props.onParseComplete, !dontIndex);
-  }
-
-  private loadExampleCards = async () => {
-    const { corpus, examples } = await getCardTextCorpus();
-
-    const bigramProbs = prepareBigramProbs(corpus);
-    this.setStateIfMounted({ bigramProbs });
-
-    exampleStore.loadExamples(examples, 100).then(() => {
-      this.setStateIfMounted({ examplesLoaded: true });
-    }).catch(console.error);
   }
 
   private renderAttributeField(attribute: 'attack' | 'health' | 'speed', enabled = true, opts: { min?: number, max?: number } = {}): JSX.Element {
@@ -482,7 +296,7 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
           maxValue={opts.max || 10}
           style={CardCreationForm.styles.attribute}
           disabled={!enabled}
-          errorText={(this as any as Record<string, string | undefined>)[`${attribute}Error`] || null}
+          errorText={this.props.validationErrors[attribute]}
           onChange={this.setAttribute(attribute)}
           inputProps={{
             startAdornment: (
@@ -497,15 +311,5 @@ export default class CardCreationForm extends React.Component<CardCreationFormPr
         />
       </div>
     );
-  }
-
-  // Prevents warnings like:
-  //   backend.js:1 Warning: Can't perform a React state update on an unmounted component.
-  //   This is a no-op, but it indicates a memory leak in your application
-  // TODO do this better with cancellable Promises or something
-  private setStateIfMounted = (newState: Partial<CardCreationFormState>) => {
-    if ((this as any)._isMounted) {
-      this.setState(newState as any);
-    }
   }
 }

--- a/src/common/components/cards/CardCreationTutorial.tsx
+++ b/src/common/components/cards/CardCreationTutorial.tsx
@@ -40,7 +40,7 @@ export default class CardCreationTutorial extends React.Component<Record<string,
           </DialogTitle>
           <DialogContent style={{ overflowY: 'hidden' }}>
             <div>This video tutorial explains how to create cards in the workshop.</div>
-            <div><em>(You can re-watch it at any time by clicking the Help button at the top of the page.)</em></div>
+            <div><em>(You can re-watch it at any time by clicking the <b>Help</b> button at the top of the page.)</em></div>
 
             <div style={{ margin: 'auto', width: 622, height: 350, padding: 20, boxSizing: 'border-box' }}>
               <IFrame

--- a/src/common/components/cards/CardCreationTutorial.tsx
+++ b/src/common/components/cards/CardCreationTutorial.tsx
@@ -1,4 +1,4 @@
-import { Icon, IconButton, Paper } from '@material-ui/core';
+import { Dialog, DialogContent, DialogTitle, Icon, IconButton } from '@material-ui/core';
 import * as React from 'react';
 import IFrame from 'react-iframe';
 
@@ -18,46 +18,43 @@ export default class CardCreationTutorial extends React.Component<Record<string,
 
     if (visible) {
       return (
-        <Paper
-          style={{
-            maxWidth: 860,
-            height: 550,
-            margin: '0 auto 15px',
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            alignItems: 'center'
+        <Dialog
+          open
+          onClose={this.handleClose}
+          PaperProps={{
+            style: {
+              width: 650,
+              maxWidth: 650,
+              height: 500
+            }
           }}
         >
-          <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
-            <Paper
-              style={{
-                fontSize: 18,
-                backgroundColor: '#f3645e',
-                color: 'white',
-                fontFamily: 'Carter One',
-                padding: '10px 15px',
-                borderBottomRightRadius: 5
-              }}
+          <DialogTitle style={{ position: 'relative' }}>
+            First time at the workshop?
+            <IconButton
+              onClick={this.handleClose}
+              style={{ position: 'absolute', top: -2, right: -2, width: 24, height: 24, margin: 10, padding: 0 }}
             >
-              First time here? Watch this tutorial!
-            </Paper>
-            <IconButton onClick={this.handleClose} style={{ width: 24, height: 24, margin: 10, padding: 0 }}>
               <Icon>close</Icon>
             </IconButton>
-          </div>
-          <div style={{ margin: 10, width: '100%', height: '100%', padding: 20, boxSizing: 'border-box' }}>
-            <IFrame
-              position="relative"
-              url="https://www.youtube.com/embed/GeZwKIOKc1c?rel=0"
-              width="100%"
-              height="100%"
-              frameborder="0"
-              allow="autoplay; encrypted-media"
-              allowFullScreen
-            />
-          </div>
-        </Paper>
+          </DialogTitle>
+          <DialogContent style={{ overflowY: 'hidden' }}>
+            <div>This video tutorial explains how to create cards in the workshop.</div>
+            <div><em>(You can re-watch it at any time by clicking the Help button at the top of the page.)</em></div>
+
+            <div style={{ margin: 'auto', width: 622, height: 350, padding: 20, boxSizing: 'border-box' }}>
+              <IFrame
+                position="relative"
+                url="https://www.youtube.com/embed/GeZwKIOKc1c?rel=0"
+                width="100%"
+                height="100%"
+                frameborder="0"
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
       );
     } else {
       return null;

--- a/src/common/components/cards/CreatorToolbarButton.tsx
+++ b/src/common/components/cards/CreatorToolbarButton.tsx
@@ -1,0 +1,34 @@
+import { Button, Icon } from '@material-ui/core';
+import * as React from 'react';
+
+import Tooltip from '../Tooltip';
+
+interface CreatorToolbarButtonProps {
+  icon: string
+  tooltip: string
+  children: string
+  onClick: () => void
+  disabled?: boolean
+  style?: React.CSSProperties
+}
+
+/* eslint-disable react/no-multi-comp */
+const CreatorToolbarButton: React.SFC<CreatorToolbarButtonProps> = (props: CreatorToolbarButtonProps) => {
+  const { icon, tooltip, children, onClick, disabled, style } = props;
+  return (
+    <Button
+      color="secondary"
+      variant="contained"
+      disabled={!!disabled}
+      style={{ marginLeft: 10, marginTop: 9, ...(style || {}) }}
+      onClick={onClick}
+    >
+      <Icon style={{ marginRight: 10 }} className="material-icons">{icon}</Icon>
+      <Tooltip inline text={tooltip} place="bottom" style={{ textTransform: 'none' }}>
+        {children}
+      </Tooltip>
+    </Button>
+  );
+};
+
+export default CreatorToolbarButton;

--- a/src/common/components/cards/CreatorToolbarButton.tsx
+++ b/src/common/components/cards/CreatorToolbarButton.tsx
@@ -9,25 +9,24 @@ interface CreatorToolbarButtonProps {
   children: string
   onClick: () => void
   disabled?: boolean
-  style?: React.CSSProperties
 }
 
 /* eslint-disable react/no-multi-comp */
 const CreatorToolbarButton: React.SFC<CreatorToolbarButtonProps> = (props: CreatorToolbarButtonProps) => {
-  const { icon, tooltip, children, onClick, disabled, style } = props;
+  const { icon, tooltip, children, onClick, disabled } = props;
   return (
-    <Button
-      color="secondary"
-      variant="contained"
-      disabled={!!disabled}
-      style={{ marginLeft: 10, marginTop: 9, ...(style || {}) }}
-      onClick={onClick}
-    >
-      <Icon style={{ marginRight: 10 }} className="material-icons">{icon}</Icon>
-      <Tooltip inline text={tooltip} place="bottom" style={{ textTransform: 'none' }}>
-        {children}
-      </Tooltip>
-    </Button>
+    <Tooltip inline text={tooltip} place="bottom" style={{ textTransform: 'none' }}>
+      <Button
+        color="secondary"
+        variant="contained"
+        disabled={!!disabled}
+        style={{ marginLeft: 10, marginTop: 9 }}
+        onClick={onClick}
+      >
+        <Icon style={{ marginRight: 10 }} className="material-icons">{icon}</Icon>
+          {children}
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/src/common/components/help/DictionaryDialog.tsx
+++ b/src/common/components/help/DictionaryDialog.tsx
@@ -171,7 +171,7 @@ export default class DictionaryDialog extends React.Component<{ history: History
   private checkHash = () => {
     const hash = getHash(this.props.history);
     if (hash && hash !== this.hash) {
-      const [ type, term ] = hash.split(':');
+      const [ type, term ] = hash.split(/:(.+)/); // https://stackoverflow.com/a/4607799
       const tabIdx = 'dtk'.indexOf(type);
 
       this.setState({ tabIdx }, () => {

--- a/src/common/components/help/DictionarySidebar.tsx
+++ b/src/common/components/help/DictionarySidebar.tsx
@@ -24,7 +24,7 @@ export default class DictionarySidebar extends React.Component<DictionarySidebar
             height: '65vh'
           }}
         >
-          <List style={{padding: 0}}>
+          <List style={{padding: 0, paddingRight: 1 }}>
             {this.props.terms.map(this.renderTerm)}
           </List>
         </Paper>

--- a/src/common/containers/Creator.tsx
+++ b/src/common/containers/Creator.tsx
@@ -1,4 +1,4 @@
-import { Button, Icon, MenuItem, Paper, Select, Snackbar } from '@material-ui/core';
+import { Icon, MenuItem, Paper, Select, Snackbar } from '@material-ui/core';
 import { find } from 'lodash';
 import * as CopyToClipboard from 'react-copy-to-clipboard';
 import * as React from 'react';
@@ -17,6 +17,7 @@ import CardCreationForm from '../components/cards/CardCreationForm';
 import CardCreationTutorial from '../components/cards/CardCreationTutorial';
 import CardPreview from '../components/cards/CardPreview';
 import CardProvenanceDescription from '../components/cards/CardProvenanceDescription';
+import CreatorToolbarButton from '../components/cards/CreatorToolbarButton';
 import RouterDialog from '../components/RouterDialog';
 import Title from '../components/Title';
 import Tooltip from '../components/Tooltip';
@@ -205,68 +206,44 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
         <Title text="Workshop" />
 
         <div style={{ display: 'inline' }}>
-          <Button
-            color="secondary"
-            variant="contained"
-            style={{ marginLeft: 20, marginTop: 9 }}
+          <CreatorToolbarButton
+            icon="queue"
+            tooltip="Reset the workshop and start a new card from scratch."
+            style={{ marginLeft: 20 }}
             onClick={this.handleClickNewCard}
           >
-            <Icon style={{ marginRight: 10 }} className="material-icons">queue</Icon>
-            <Tooltip inline text="Reset the workshop and start a new card from scratch." place="bottom" style={{ textTransform: 'none' }}>
-              New Card
-            </Tooltip>
-          </Button>
-          <Button
-            color="secondary"
-            variant="contained"
-            style={{ marginLeft: 10, marginTop: 9 }}
+            New Card
+          </CreatorToolbarButton>
+          <CreatorToolbarButton
+            icon="help_outline"
+            tooltip="Learn more about creating a card."
             onClick={this.handleClickHelp}
           >
-            <Icon style={{ marginRight: 10 }} className="material-icons">help_outline</Icon>
-            <Tooltip inline text="Learn more about creating a card." place="bottom" style={{ textTransform: 'none' }}>
-              Help
-            </Tooltip>
-          </Button>
-          <Button
-            color="secondary"
-            variant="contained"
-            style={{ marginLeft: 10, marginTop: 9 }}
+            Help
+          </CreatorToolbarButton>
+          <CreatorToolbarButton
+            icon="book"
+            tooltip="Check out all of the terms and actions that the parser supports."
             onClick={this.handleClickDictionary}
           >
-            <Icon style={{ marginRight: 10 }} className="material-icons">book</Icon>
-            <Tooltip inline text="Check out all of the terms and actions that the parser supports." place="bottom" style={{ textTransform: 'none' }}>
-              Dictionary
-            </Tooltip>
-          </Button>
-          <Button
-            color="secondary"
-            variant="contained"
-            style={{ marginLeft: 10, marginTop: 9 }}
+            Dictionary
+          </CreatorToolbarButton>
+          <CreatorToolbarButton
+            icon="refresh"
+            tooltip={`Generate random text for the card. ${examplesLoaded ? '' : '(Loading examples ...)'}`}
             onClick={this.handleClickRandomize}
             disabled={!examplesLoaded || !this.isCardEditable}
           >
-            <Icon style={{ marginRight: 10 }} className="material-icons">refresh</Icon>
-            <Tooltip
-              inline
-              text={`Generate random text for the card. ${examplesLoaded ? '' : '(Loading examples ...)'}`}
-              place="bottom"
-              style={{ textTransform: 'none' }}
-            >
-              Randomize
-            </Tooltip>
-          </Button>
-          <Button
-            color="secondary"
-            variant="contained"
-            style={{ marginLeft: 10, marginTop: 9 }}
+            Randomize
+          </CreatorToolbarButton>
+          <CreatorToolbarButton
+            icon="videogame_asset"
+            tooltip="Test out this card in sandbox mode."
             onClick={this.testCard}
             disabled={!this.validationResults.isValid}
           >
-            <Icon style={{ marginRight: 10 }} className="material-icons">videogame_asset</Icon>
-            <Tooltip inline text="Test out this card in sandbox mode." place="bottom" style={{ textTransform: 'none' }}>
-              Test
-            </Tooltip>
-          </Button>
+            Test
+          </CreatorToolbarButton>
         </div>
 
         <div style={{

--- a/src/common/containers/Creator.tsx
+++ b/src/common/containers/Creator.tsx
@@ -205,11 +205,10 @@ export class Creator extends React.Component<CreatorProps, CreatorState> {
         <Helmet title="Workshop" />
         <Title text="Workshop" />
 
-        <div style={{ display: 'inline' }}>
+        <div style={{ display: 'inline', paddingLeft: 10 }}>
           <CreatorToolbarButton
             icon="queue"
             tooltip="Reset the workshop and start a new card from scratch."
-            style={{ marginLeft: 20 }}
             onClick={this.handleClickNewCard}
           >
             New Card

--- a/styles/index.css
+++ b/styles/index.css
@@ -219,3 +219,15 @@ a.topLink:hover {
     display: none !important;
   }
 }
+
+@media only screen and (max-width: 1300px) {
+  .workshop-arrow .material-icons {
+    font-size: 75px !important;
+  }
+}
+
+@media only screen and (max-width: 1100px) {
+  .workshop-arrow .material-icons {
+    font-size: 50px !important;
+  }
+}


### PR DESCRIPTION
[ fix #1453, fix #1454, fix #1456, fix #1459, fix #1460, fix #1462 ]

* Move all the menu buttons to a single row at the top of the page (this required significant refactoring)
* Move the copy permalink button down to the card provenance status box
* Make the "first time here" tutorial area a dialog
* Make card text and flavor text input boxes multiline
* Debounce card text input box to make it super responsive
* Fix some bugs in keywords tab of the dictionary dialog
* Scale the arrow between the blueprint and created card to fit well at all screen sizes

![image](https://user-images.githubusercontent.com/415965/116527391-77e1ab80-a88f-11eb-9605-e487b1c88df2.png)
![image](https://user-images.githubusercontent.com/415965/116527367-72846100-a88f-11eb-8484-1ae4e2717e54.png)
