### PR TITLE
Fix a smorgasbord of bugs and UI issues based on playtest with Danny

### DIFF
--- a/src/common/components/card/CardTooltip.tsx
+++ b/src/common/components/card/CardTooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import * as ReactTooltip from 'react-tooltip';
 
 import { MAX_Z_INDEX } from '../../constants';
@@ -39,15 +40,19 @@ export default class CardTooltip extends React.Component<CardTooltipProps> {
           <span data-tip="" data-for={this.tooltipId}>
             {this.props.children}
           </span>
-          <span style={{ zIndex: MAX_Z_INDEX, backgroundColor: 'transparent' }}>
-            <ReactTooltip
-              id={this.tooltipId}
-              className="hovered-card"
-              place="top"
-            >
-              {Card.fromObj(this.props.card)}
-            </ReactTooltip>
-          </span>
+          {
+            ReactDOM.createPortal(
+              <ReactTooltip
+                id={this.tooltipId}
+                className="hovered-card"
+                place="top"
+                style={{ zIndex: MAX_Z_INDEX }}
+              >
+                {Card.fromObj(this.props.card)}
+              </ReactTooltip>,
+              document.querySelector('#modal-root')!
+            )
+          }
         </span>
       );
     }

--- a/src/common/components/card/CardTooltip.tsx
+++ b/src/common/components/card/CardTooltip.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import * as ReactTooltip from 'react-tooltip';
 
 import { MAX_Z_INDEX } from '../../constants';
 import * as w from '../../types';
+import { createSafePortal } from '../../util/browser';
 import { id } from '../../util/common';
 import Popover from '../Popover';
 
@@ -41,7 +41,7 @@ export default class CardTooltip extends React.Component<CardTooltipProps> {
             {this.props.children}
           </span>
           {
-            ReactDOM.createPortal(
+            createSafePortal(
               <ReactTooltip
                 id={this.tooltipId}
                 className="hovered-card"

--- a/src/common/components/game/EndTurnButton.tsx
+++ b/src/common/components/game/EndTurnButton.tsx
@@ -32,8 +32,7 @@ export default class EndTurnButton extends React.Component<EndTurnButtonProps> {
   }
 
   public render(): JSX.Element {
-    const { player, compact, tutorialStep, onNextTutorialStep, onPrevTutorialStep } = this.props;
-    const height = compact ? '40px' : '64px';
+    const { player, isMyTurn, compact, tutorialStep, onNextTutorialStep, onPrevTutorialStep } = this.props;
 
     return (
       <TutorialTooltip
@@ -45,7 +44,7 @@ export default class EndTurnButton extends React.Component<EndTurnButtonProps> {
         onPrevStep={onPrevTutorialStep}
       >
         <Button
-          className="end-turn-button"
+          className={`end-turn-button ${player} ${!isMyTurn && 'waiting'}`}
           variant="contained"
           style={{
             backgroundColor: player ? {orange: ORANGE_PLAYER_COLOR, blue: BLUE_PLAYER_COLOR}[player] : undefined,
@@ -54,7 +53,8 @@ export default class EndTurnButton extends React.Component<EndTurnButtonProps> {
             color: '#FFF',
             fontFamily: 'Carter One',
             fontSize: compact ? 22 : 32,
-            height,
+            width: compact ? 150 : 220,
+            height: compact ? 40 : 64,
             padding: compact ? '0 5px' : '0 15px'
           }}
           onClick={this.handleClick}
@@ -66,7 +66,7 @@ export default class EndTurnButton extends React.Component<EndTurnButtonProps> {
           >
             timer
           </Icon>
-          End Turn
+          {isMyTurn ? 'End Turn' : 'Waiting'}
         </Button>
       </TutorialTooltip>
     );

--- a/src/common/components/game/EnergyCount.tsx
+++ b/src/common/components/game/EnergyCount.tsx
@@ -56,9 +56,9 @@ export default class EnergyCount extends React.Component<EnergyCountProps> {
         key={id()}
         style={{
           height: 64,
-          width: 18,
+          width: 16,
           backgroundColor: filled ? {orange: ORANGE_PLAYER_COLOR, blue: BLUE_PLAYER_COLOR}[color] : 'transparent',
-          marginLeft: 8,
+          marginLeft: 6,
           border: '3px solid white',
           borderRadius: 4
         }}

--- a/src/common/components/game/ForfeitButton.tsx
+++ b/src/common/components/game/ForfeitButton.tsx
@@ -3,10 +3,8 @@ import Button from '@material-ui/core/Button';
 import Icon from '@material-ui/core/Icon';
 import * as React from 'react';
 
-import { MAX_Z_INDEX } from '../../constants';
 import * as w from '../../types';
 import { opponent } from '../../util/game';
-import Tooltip from '../Tooltip';
 
 interface ForfeitButtonProps {
   player: w.PlayerColor | null
@@ -21,33 +19,33 @@ interface ForfeitButtonProps {
 export default class ForfeitButton extends React.Component<ForfeitButtonProps> {
   public render(): JSX.Element {
     const { compact, gameOver, isSpectator } = this.props;
-    const height = compact ? '40px' : '64px';
 
     return (
-      <Tooltip text="Forfeit" place="top" style={{ zIndex: MAX_Z_INDEX }}>
-        <Button
-          className="forfeit-button"
-          variant="contained"
-          style={{
-            backgroundColor: 'black',
-            border: '2px solid white',
-            borderRadius: 5,
-            height,
-            marginLeft: 10,
-            minWidth: 48,
-            padding: 10
-          }}
-          onClick={this.handleClick}
-          disabled={isSpectator || gameOver}
+      <Button
+        className="forfeit-button"
+        variant="contained"
+        style={{
+          backgroundColor: 'black',
+          border: '1px solid white',
+          borderRadius: 5,
+          width: compact ? 150 : 220,
+          height: compact ? 26 : 36,
+          marginTop: 5,
+          padding: compact ? 5 : 10,
+          color: '#FFF',
+          fontFamily: 'Carter One'
+        }}
+        onClick={this.handleClick}
+        disabled={isSpectator || gameOver}
+      >
+        <Icon
+          className="material-icons"
+          style={{ color: '#ffffff' }}
         >
-          <Icon
-            className="material-icons"
-            style={{ color: '#ffffff' }}
-          >
-            flag
-          </Icon>
-        </Button>
-      </Tooltip>
+          flag
+        </Icon>
+        Forfeit
+      </Button>
     );
   }
 
@@ -55,9 +53,13 @@ export default class ForfeitButton extends React.Component<ForfeitButtonProps> {
     const { player, isTutorial, history, onForfeit } = this.props;
 
     if (player) {
-      onForfeit(opponent(player));
       if (isTutorial) {
+        onForfeit(opponent(player));
         history.push('/play');
+      } else {
+        if (confirm('Are you sure you want to forfeit?')) {
+          onForfeit(opponent(player));
+        }
       }
     }
   }

--- a/src/common/components/game/GameArea.tsx
+++ b/src/common/components/game/GameArea.tsx
@@ -5,7 +5,7 @@ import { RouteComponentProps } from 'react-router';
 import * as screenfull from 'screenfull';
 
 import {
-  BACKGROUND_Z_INDEX, BOARD_Z_INDEX, CHAT_COLLAPSED_WIDTH, CHAT_NARROW_WIDTH,
+  BACKGROUND_Z_INDEX, BOARD_Z_INDEX, LEFT_CONTROLS_Z_INDEX, CHAT_COLLAPSED_WIDTH, CHAT_NARROW_WIDTH,
   CHAT_WIDTH, HEADER_HEIGHT, MAX_BOARD_SIZE, SIDEBAR_COLLAPSED_WIDTH
 } from '../../constants';
 import { GameAreaContainerProps } from '../../containers/GameAreaContainer';
@@ -185,7 +185,7 @@ export default class GameArea extends React.Component<GameAreaProps, GameAreaSta
                 justifyContent: 'center',
                 alignItems: 'center',
                 marginLeft: 20,
-                zIndex: BACKGROUND_Z_INDEX
+                zIndex: LEFT_CONTROLS_Z_INDEX
               }}
             >
               <Timer
@@ -211,9 +211,9 @@ export default class GameArea extends React.Component<GameAreaProps, GameAreaSta
             <div
               className="background"
               style={{
-                display: 'flex',
-                justifyContent: 'center',
                 marginRight: 20,
+                maxWidth: 220,
+                textAlign: 'right',
                 zIndex: BACKGROUND_Z_INDEX
               }}
             >
@@ -306,8 +306,7 @@ export default class GameArea extends React.Component<GameAreaProps, GameAreaSta
     const navSidebarWidth = this.urlMatchesGameMode('sandbox') ? SIDEBAR_COLLAPSED_WIDTH : 0;
 
     const topBottomMargin = 80;
-    const leftMargin = 80;
-    const rightMargin = compactControls ? 270 : 310;
+    const leftRightMargin = 200;
 
     this.setState(({ chatOpen }) => {
       const chatWidth = !chatOpen ? CHAT_COLLAPSED_WIDTH : (compactControls ? CHAT_NARROW_WIDTH : CHAT_WIDTH);
@@ -316,7 +315,7 @@ export default class GameArea extends React.Component<GameAreaProps, GameAreaSta
       const areaWidth = window.innerWidth - chatWidth - navSidebarWidth;
 
       const maxBoardHeight = areaHeight - topBottomMargin * 2;
-      const maxBoardWidth = areaWidth - leftMargin - rightMargin;
+      const maxBoardWidth = areaWidth - (2 * leftRightMargin);
       const boardSize = Math.min(maxBoardWidth, maxBoardHeight, MAX_BOARD_SIZE);
 
       return {
@@ -326,7 +325,7 @@ export default class GameArea extends React.Component<GameAreaProps, GameAreaSta
           // On a large enough screen (areaWidth > 1300), center the board in the exact middle of the game area.
           // On smaller screens (areaWidth < 1300), position the board halfway between the controls on the left and right sides.
           // (This moves the board closer to the left because the left controls (volume, &c) are much narrower than the right (End Turn, &c))
-          left: areaWidth > 1300 ? (areaWidth - boardSize) / 2 : leftMargin + (maxBoardWidth - boardSize) / 2,
+          left: areaWidth > 1300 ? (areaWidth - boardSize) / 2 : leftRightMargin + (maxBoardWidth - boardSize) / 2,
           top: topBottomMargin + (maxBoardHeight - boardSize) / 2
         },
         compactControls,

--- a/src/common/components/play/ChatMessage.tsx
+++ b/src/common/components/play/ChatMessage.tsx
@@ -44,7 +44,7 @@ export default class ChatMessage extends React.Component<ChatMessageProps> {
       return (
         <CardTooltip key={key} card={card}>
           <span style={{fontWeight: 'bold', cursor: 'pointer'}}>
-            {phrase}
+            {card.name}
           </span>
         </CardTooltip>
       );

--- a/src/common/components/play/PreGameModal.tsx
+++ b/src/common/components/play/PreGameModal.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import * as w from '../../types';
 import { unpackDeck } from '../../util/cards';
 import { sortDecks } from '../../util/decks';
-import { BUILTIN_FORMATS, GameFormat, SetFormat } from '../../util/formats';
+import { BuiltinOnlyGameFormat, BUILTIN_FORMATS, GameFormat, NormalGameFormat, SetFormat } from '../../util/formats';
 import RouterDialog from '../RouterDialog';
 
 import DeckPicker from './DeckPicker';
@@ -38,7 +38,7 @@ interface PreGameModalState {
 export default class PreGameModal extends React.Component<PreGameModalProps, PreGameModalState> {
   public state: PreGameModalState = {
     selectedDeckId: null,
-    selectedFormatName: 'sharedDeck',
+    selectedFormatName: this.props.mode === 'practice' ? 'normal' : 'sharedDeck',
     enteredPassword: '',
     isPasswordInvalid: false
   };
@@ -52,20 +52,25 @@ export default class PreGameModal extends React.Component<PreGameModalProps, Pre
     return format || formats.find((f) => f.name === selectedFormatName)!;
   }
 
-  // The full list of formats that are available to the player.
+  // The full list of formats that are available to the player (given the game mode).
   get availableFormats(): GameFormat[] {
-    const { sets } = this.props;
-    const setFormats = uniqBy(compact(this.decks.map((deck) => {
-      const set = sets.find((s) => s.id === deck.setId);
-      if (set) {
-        const setFormat = new SetFormat(set);
-        if (setFormat.isDeckValid(deck)) {
-          return setFormat;
-        }
-      }
-    })), 'name');
+    const { mode, sets } = this.props;
 
-    return [...BUILTIN_FORMATS, ...setFormats];
+    if (mode === 'practice') {
+      return [NormalGameFormat, BuiltinOnlyGameFormat];
+    } else {
+      const setFormats = uniqBy(compact(this.decks.map((deck) => {
+        const set = sets.find((s) => s.id === deck.setId);
+        if (set) {
+          const setFormat = new SetFormat(set);
+          if (setFormat.isDeckValid(deck)) {
+            return setFormat;
+          }
+        }
+      })), 'name');
+
+      return [...BUILTIN_FORMATS, ...setFormats];
+    }
   }
 
   // All of the player's decks, in an unpacked format ready to start the game with.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -89,6 +89,7 @@ export const SIDEBAR_Z_INDEX = 920;
 export const CHAT_Z_INDEX = 920;
 export const DIALOG_Z_INDEX = 970;
 export const BOARD_Z_INDEX = 1000;
+export const LEFT_CONTROLS_Z_INDEX = 1500;
 export const STATUS_Z_INDEX = 2000;
 export const HAND_Z_INDEX = 50000;
 export const MAX_Z_INDEX = 99910;

--- a/src/common/reducers/handlers/game/board.ts
+++ b/src/common/reducers/handlers/game/board.ts
@@ -69,7 +69,7 @@ export function moveRobot(state: State, fromHex: w.HexId, toHex: w.HexId): State
     movingRobot.movedThisTurn = true;
 
     state = triggerSound(state, 'move.wav');
-    state = logAction(state, player, `moved |${movingRobot.card.name}|`, {[movingRobot.card.name]: movingRobot.card});
+    state = logAction(state, player, `moved |${movingRobot.card.id}|`, {[movingRobot.card.id]: movingRobot.card});
     state = transportObject(state, fromHex, toHex);
     state = triggerEvent(state, 'afterMove', {object: movingRobot});
     state = applyAbilities(state);
@@ -87,7 +87,7 @@ export function moveObjectUsingAbility(state: State, fromHex: w.HexId, toHex: w.
   if (!allObjectsOnBoard(state)[toHex]) {
     const movingRobot: w.Object = allObjectsOnBoard(state)[fromHex];
 
-    state = logAction(state, null, `|${movingRobot.card.name}| was moved`, {[movingRobot.card.name]: movingRobot.card});
+    state = logAction(state, null, `|${movingRobot.card.id}| was moved`, {[movingRobot.card.id]: movingRobot.card});
     state = transportObject(state, fromHex, toHex);
     state = applyAbilities(state);
     state = updateOrDeleteObjectAtHex(state, movingRobot, toHex);
@@ -122,9 +122,9 @@ export function attack(state: State, source: w.HexId, target: w.HexId): State {
       attacker.attackedThisTurn = true;
 
       state = triggerSound(state, 'attack.wav');
-      state = logAction(state, player, `attacked |${defender.card.name}| with |${attacker.card.name}|`, {
-        [defender.card.name]: defender.card,
-        [attacker.card.name]: attacker.card
+      state = logAction(state, player, `attacked |${defender.card.id}| with |${attacker.card.id}|`, {
+        [defender.card.id]: defender.card,
+        [attacker.card.id]: attacker.card
       });
       state.attack = {from: source, to: target};
       state = deselect(state);
@@ -196,11 +196,11 @@ export function activateObject(state: State, abilityIdx: number, selectedHexId: 
     const player: PlayerState = currentPlayer(tempState);
     const ability: w.ActivatedAbility = object.activatedAbilities![abilityIdx];
 
-    const logMsg = `activated |${object.card.name}|'s "${ability.text}" ability`;
+    const logMsg = `activated |${object.card.id}|'s "${ability.text}" ability`;
     const target: w.Targetable | null = player.target.chosen ? player.target.chosen[0] : null;
 
     tempState = triggerSound(tempState, 'event.wav');
-    tempState = logAction(tempState, player, logMsg, {[object.card.name]: object.card}, null, target);
+    tempState = logAction(tempState, player, logMsg, {[object.card.id]: object.card}, null, target);
 
     executeCmd(tempState, ability.cmd, object);
 

--- a/src/common/reducers/handlers/game/cards.ts
+++ b/src/common/reducers/handlers/game/cards.ts
@@ -95,12 +95,12 @@ export function instantiateObject(card: w.CardInGame): w.Object {
 // Handles things that should happen after an object is played or spawned (using actions.spawnObject).
 export function afterObjectPlayed(state: State, playedObject: w.Object): State {
   const player: PlayerState = currentPlayer(state);
-  const target = player.target.chosen ? player.target.chosen[0] : null;
+  const target = (player.target.choosing && player.target.chosen) ? player.target.chosen[0] : null;
   const { card } = playedObject;
   const timestamp = Date.now();
 
   state = triggerSound(state, 'spawn.wav');
-  state = logAction(state, player, `played |${card.name}|`, {[card.name]: card}, timestamp, target);
+  state = logAction(state, player, `played |${card.id}|`, {[card.id]: card}, timestamp, target);
 
   if (card.abilities && card.abilities.length > 0) {
     card.abilities.forEach((cmd, idx) => {
@@ -183,7 +183,7 @@ function playEvent(state: State, cardIdx: number): State {
     const target = player.target.chosen ? player.target.chosen[0] : null;
 
     tempState = triggerSound(tempState, 'event.wav');
-    tempState = logAction(tempState, player, `played |${card.name}|`, {[card.name]: card}, timestamp, target);
+    tempState = logAction(tempState, player, `played |${card.id}|`, {[card.id]: card}, timestamp, player.target.choosing && target || null);
     tempState.eventExecuting = true;
 
     const commands: string[] = compact(isArray(card.command) ? card.command : [card.command]);

--- a/src/common/reducers/handlers/game/practice.tsx
+++ b/src/common/reducers/handlers/game/practice.tsx
@@ -27,7 +27,7 @@ export function startPractice(state: State, format: w.Format, deck: w.CardInGame
     blue: shuffle(aiDeck)
   };
 
-  state = newGame(state, 'orange', {orange: lookupUsername(), blue: 'Computer'}, decks, '0', format);
+  state = newGame(state, 'orange', {orange: lookupUsername(), blue: 'Computer'}, decks, 0, format);
   state.practice = true;
 
   return state;

--- a/src/common/util/browser.tsx
+++ b/src/common/util/browser.tsx
@@ -1,6 +1,8 @@
 import { detect, Browser } from 'detect-browser';
 import { History } from 'history';
 import * as ReactGA from 'react-ga';
+import * as ReactDOM from 'react-dom';
+import { ReactNode, ReactPortal } from 'react';
 
 declare const window: {
   location: { pathname: string, hostname: string }
@@ -94,4 +96,12 @@ export function isSupportedBrowser(): boolean {
   }
 
   return false;
+}
+
+export function createSafePortal(children: ReactNode, container: Element): ReactPortal | null {
+  if (inBrowser()) {
+    return ReactDOM.createPortal(children, container);
+  } else {
+    return null;
+  }
 }

--- a/src/common/util/formats.tsx
+++ b/src/common/util/formats.tsx
@@ -131,10 +131,7 @@ export const SharedDeckGameFormat = new (class extends GameFormat {
   ): w.GameState {
     state = super.startGame(state, player, usernames, decks, options, seed);
 
-    console.log(seed);
-
     const deck = shuffle([...decks.blue, ...decks.orange], seed);
-    console.log(deck);
     // Give blue the top two cards, orange the next two (to form their starting hands),
     // and both players the rest of the deck.
     const [topTwo, nextTwo, restOfDeck] = [deck.slice(0, 2), deck.slice(2, 4), deck.slice(4)];

--- a/src/common/util/formats.tsx
+++ b/src/common/util/formats.tsx
@@ -64,14 +64,14 @@ export class GameFormat {
 
   public startGame(
     state: w.GameState, player: w.PlayerColor, usernames: w.PerPlayer<string>,
-    _decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: string
+    _decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: number
   ): w.GameState {
     state = {
       ...state,
       ...cloneDeep(defaultState),
       gameFormat: this.serialized(),
       player,
-      rng: seededRNG(seed),
+      rng: seededRNG(seed.toString()),
       started: true,
       usernames,
       options};
@@ -90,7 +90,7 @@ export const NormalGameFormat = new (class extends GameFormat {
 
   public startGame(
     state: w.GameState, player: w.PlayerColor, usernames: w.PerPlayer<string>,
-    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: string
+    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: number
   ): w.GameState {
     state = super.startGame(state, player, usernames, decks, options, seed);
 
@@ -112,7 +112,7 @@ export const BuiltinOnlyGameFormat = new (class extends GameFormat {
 
   public startGame(
     state: w.GameState, player: w.PlayerColor, usernames: w.PerPlayer<string>,
-    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: string
+    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: number
   ): w.GameState {
     return NormalGameFormat.startGame(state, player, usernames, decks, options, seed);
   }
@@ -127,11 +127,14 @@ export const SharedDeckGameFormat = new (class extends GameFormat {
 
   public startGame(
     state: w.GameState, player: w.PlayerColor, usernames: w.PerPlayer<string>,
-    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: string
+    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: number
   ): w.GameState {
     state = super.startGame(state, player, usernames, decks, options, seed);
 
+    console.log(seed);
+
     const deck = shuffle([...decks.blue, ...decks.orange], seed);
+    console.log(deck);
     // Give blue the top two cards, orange the next two (to form their starting hands),
     // and both players the rest of the deck.
     const [topTwo, nextTwo, restOfDeck] = [deck.slice(0, 2), deck.slice(2, 4), deck.slice(4)];
@@ -186,7 +189,7 @@ export class SetFormat extends GameFormat {
 
   public startGame(
     state: w.GameState, player: w.PlayerColor, usernames: w.PerPlayer<string>,
-    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: string
+    decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>, options: w.GameOptions, seed: number
   ): w.GameState {
     return NormalGameFormat.startGame(state, player, usernames, decks, options, seed);
   }

--- a/src/common/util/game.ts
+++ b/src/common/util/game.ts
@@ -293,7 +293,7 @@ export function logAction(
   state: w.GameState,
   player: w.PlayerInGameState | null,
   action: string,
-  cards: Record<string, w.CardInGame> = {},
+  cards: Record<w.CardId, w.CardInGame> = {},
   timestamp: number | null = null,
   target: w.Targetable | null = null
 ): w.GameState {
@@ -304,8 +304,8 @@ export function logAction(
     '';
 
   target = determineTargetCard(state, target);
-  const targetStr = target ? `, targeting |${target.name}|` : '';
-  const targetCards = target ? {[target.name]: target} : {};
+  const targetStr = target ? `, targeting |${target.id}|` : '';
+  const targetCards = target ? {[target.id]: target} : {};
 
   const message = {
     id: state.actionId!,
@@ -325,7 +325,7 @@ export function newGame(
   player: w.PlayerColor,
   usernames: w.PerPlayer<string>,
   decks: w.PerPlayer<w.PossiblyObfuscatedCard[]>,
-  seed = '0',
+  seed = 0,
   gameFormat: w.Format = DEFAULT_GAME_FORMAT,
   gameOptions: w.GameOptions = {}
 ): w.GameState {
@@ -509,7 +509,7 @@ export function dealDamageToObjectAtHex(state: w.GameState, amount: number, hex:
   if (!object.beingDestroyed) {
     object.stats.health -= amount;
     object.tookDamageThisTurn = true;
-    state = logAction(state, null, `|${object.card.name}| received ${amount} damage`, {[object.card.name]: object.card});
+    state = logAction(state, null, `|${object.card.id}| received ${amount} damage`, {[object.card.id]: object.card});
     state = triggerEvent(state, 'afterDamageReceived', {object});
   }
 
@@ -537,7 +537,7 @@ export function updateOrDeleteObjectAtHex(
     object.beingDestroyed = true;
 
     state = triggerSound(state, 'destroyed.wav');
-    state = logAction(state, null, `|${object.card.name}| was destroyed`, {[object.card.name]: object.card});
+    state = logAction(state, null, `|${object.card.id}| was destroyed`, {[object.card.id]: object.card});
     state = triggerEvent(state, 'afterDestroyed', {object, condition: ((t: w.Trigger) => (t.cause === cause || t.cause === 'anyevent'))});
     if (cause === 'combat' && object.mostRecentlyInCombatWith) {
       state = triggerEvent(state, 'afterDestroysOtherObject', {

--- a/src/server/handleRequest.tsx
+++ b/src/server/handleRequest.tsx
@@ -82,6 +82,7 @@ function renderFullPage(html: string, head: HelmetData): string {
       </head>
       <body style="margin: 0;">
           <div id="root">${html}</div>
+          <div id="modal-root"></div>
           <script>
             window.VERSION = '${packagejson.version}+${process.env.HEROKU_SLUG_COMMIT || 'local'}';
           </script>

--- a/src/server/multiplayer/MultiplayerServerState.ts
+++ b/src/server/multiplayer/MultiplayerServerState.ts
@@ -200,7 +200,7 @@ export default class MultiplayerServerState {
       const { name, format, options } = waitingPlayer;
       const decks = { orange: waitingPlayer.deck.cards.map(instantiateCard), blue: deck.cards.map(instantiateCard) };
       const usernames =  {orange: this.getClientUsername(opponentID), blue: this.getClientUsername(clientID)};
-      const seed = generateID();
+      const seed = Math.random();
 
       const initialGameState: m.GameState = formatObj!.startGame(defaultGameState, 'orange', usernames, decks, options, seed);
 

--- a/src/server/multiplayer/multiplayer.d.ts
+++ b/src/server/multiplayer/multiplayer.d.ts
@@ -38,7 +38,7 @@ export interface Game {
   state: GameState
   decks: { blue: ObfuscatedCard[], orange: ObfuscatedCard[] }
   usernames: { blue: string, orange: string }
-  startingSeed: string
+  startingSeed: number
   winner: w.PlayerColor | null
   options: GameOptions
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -178,6 +178,22 @@ a.topLink:hover {
   box-shadow: 0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22);
 }
 
+.end-turn-button.orange:enabled:hover {
+  background-color: #d99237 !important;
+}
+
+.end-turn-button.blue:enabled:hover {
+  background-color: #94b5d9 !important;
+}
+
+.end-turn-button.waiting {
+  opacity: 0.7;
+}
+
+.forfeit-button:enabled:hover {
+  background-color: #333 !important;
+}
+
 .volume-slider {
   transition: visibility 100ms ease-in-out, opacity 100ms ease-in-out;
 }

--- a/styles/lib.css
+++ b/styles/lib.css
@@ -57,6 +57,7 @@
 
 .hovered-card.__react_component_tooltip {
   background-color: transparent !important;
+  z-index: 999999;
 }
 
 .hovered-card.__react_component_tooltip.show {


### PR DESCRIPTION
[ close #1463, close #1464, close #1465, close #1466, close #1467, close #1468, close #1469, close #1470, close #1471, close #1472 ]

- Only Anything Goes and Builtins Only formats should be playable in practice mode (bot doesn't know how to play Mash-Up)
- Card previews can get cut off in game log
- Global actions incorrectly display targets in game log
- "Reinforcements" card doesn't render preview correctly in game log
- sharedDeck mode doesn't shuffle decks together property
- Confirmation dialog when clicking Forfeit button
- Better hover state for End Turn and Forfeit buttons
- Move forfeit button to separate row to make right controls take up less space
- Center the board within the game area
- Z-index issues: volume slider, energy bars, card previews in game log all get hidden behind board and other game elements