### PR TITLE
Show current abilities, triggers, and stats for objects in CardTooltip

### DIFF
--- a/src/common/components/card/CardStat.tsx
+++ b/src/common/components/card/CardStat.tsx
@@ -1,4 +1,4 @@
-import { capitalize } from 'lodash';
+import { capitalize, isNumber } from 'lodash';
 import Icon from '@material-ui/core/Icon';
 import * as React from 'react';
 
@@ -31,9 +31,9 @@ export default class CardStat extends React.Component<CardStatProps> {
 
   get textColor(): string {
     const { base, current } = this.props;
-    if (current && base && current > base) {
+    if (isNumber(current) && isNumber(base) && current > base) {
       return '#81C784';
-    } else if (current && base && current < base) {
+    } else if (isNumber(current) && isNumber(base) && current < base) {
       return '#E57373';
     } else {
       return '#444';
@@ -55,22 +55,23 @@ export default class CardStat extends React.Component<CardStatProps> {
   }
 
   get statText(): JSX.Element {
+    const { base, current, scale } = this.props;
     const baseStatStyle: React.CSSProperties = {
       position: 'absolute',
       top: -5,
       left: -10,
       color: 'black',
-      fontSize: 10 * (this.props.scale || 1),
+      fontSize: 10 * (scale || 1),
       textDecoration: 'line-through'
     };
 
-    if (this.props.current && this.props.current !== this.props.base) {
+    if (current && current !== base) {
       return (
         <span style={{position: 'relative'}}>
           <span style={baseStatStyle}>
-            &nbsp;{this.props.base}&nbsp;
+            &nbsp;{base}&nbsp;
           </span>
-          {this.props.current}
+          {current}
         </span>
       );
     } else {

--- a/src/common/components/card/CardTooltip.tsx
+++ b/src/common/components/card/CardTooltip.tsx
@@ -4,14 +4,22 @@ import * as ReactTooltip from 'react-tooltip';
 import { MAX_Z_INDEX } from '../../constants';
 import * as w from '../../types';
 import { createSafePortal } from '../../util/browser';
-import { id } from '../../util/common';
+import { id, withTrailingPeriod } from '../../util/common';
 import Popover from '../Popover';
 
 import { Card } from './Card';
+import Sentence from './Sentence';
 
 interface CardTooltipProps {
-  card: w.CardInStore
   children: JSX.Element | JSX.Element[]
+  card: w.CardInStore
+  stats?: {
+    attack?: number
+    health: number
+    speed?: number
+  }
+  abilities?: w.PassiveAbility[]
+  triggers?: w.TriggeredAbility[]
   popover?: boolean
   isOpen?: boolean
 }
@@ -20,25 +28,46 @@ export default class CardTooltip extends React.Component<CardTooltipProps> {
   private tooltipId = id();
 
   public render(): JSX.Element | JSX.Element[] {
-    if (!this.props.card) {
-      return this.props.children;
-    } else if (this.props.popover) {
+    const { children, card, stats, abilities, triggers, popover, isOpen } = this.props;
+
+    if (!card) {
+      return children;
+    } else if (popover) {
+      // Append text from abilities and triggers that have been added to the object
+      // (that is, abilities and triggers that are on the object but aren't on the original card).
+      // TODO unit-test this functionality because it's a little finicky!
+      const cardText: string = withTrailingPeriod((card.text as string));
+      const additionalText: string = (
+        [...abilities || [], ...triggers || []]
+          .filter((a) => a.source && a.text)
+          .map((a) => withTrailingPeriod(a.text))
+          .join('\n')
+      );
+      const medialNewline: string = (cardText && additionalText) ? '\n' : '';
+      const sentences: JSX.Element[] = Sentence.fromTextChunks([
+        { text: cardText },
+        { text: `${medialNewline}${additionalText}`, color: 'green' }
+      ]);
+
       return (
         <Popover
-          isOpen={this.props.isOpen}
-          body={Card.fromObj(this.props.card)}
+          isOpen={isOpen}
+          body={Card.fromObj(card, {
+            stats: stats || card.stats,
+            text: sentences
+          })}
           style={{ zIndex: MAX_Z_INDEX }}
           preferPlace="above"
           showTip={false}
         >
-          {this.props.children}
+          {children}
         </Popover>
       );
     } else {
       return (
         <span>
           <span data-tip="" data-for={this.tooltipId}>
-            {this.props.children}
+            {children}
           </span>
           {
             createSafePortal(
@@ -48,7 +77,7 @@ export default class CardTooltip extends React.Component<CardTooltipProps> {
                 place="top"
                 style={{ zIndex: MAX_Z_INDEX }}
               >
-                {Card.fromObj(this.props.card)}
+                {Card.fromObj(card)}
               </ReactTooltip>,
               document.querySelector('#modal-root')!
             )

--- a/src/common/components/game/Board.tsx
+++ b/src/common/components/game/Board.tsx
@@ -84,9 +84,12 @@ export default class Board extends React.Component<BoardProps, BoardState> {
       stats: {
         health: getAttribute(piece, 'health')!,
         attack: getAttribute(piece, 'attack'),
+        speed: getAttribute(piece, 'speed'),
         movesUsed: (piece && getAttribute(piece, 'speed') !== undefined) ? (getAttribute(piece, 'speed')! - movesLeft(piece as w.Robot)) : undefined,
         movesAvailable: (piece && getAttribute(piece, 'speed') !== undefined) ? movesLeft(piece as w.Robot) : undefined
       },
+      abilities: piece.abilities,
+      triggers: piece.triggers,
       attacking: (attack && attack.from === hex && !attack.retract) ? attack.to : null,
       isDamaged: !!piece.tookDamageThisTurn
     }));

--- a/src/common/components/hexgrid/HexGrid.tsx
+++ b/src/common/components/hexgrid/HexGrid.tsx
@@ -73,19 +73,26 @@ export default class HexGrid extends React.Component<HexShapeProps> {
   }
 
   private renderHexes(): JSX.Element[] {
-    return this.props.hexagons.map((hex, index) => (
-      <HexShape
-        key={index}
-        hex={hex}
-        card={(this.props.pieces[HexUtils.getID(hex)] || {}).card}
-        layout={this.props.layout}
-        actions={this.props.actions}
-        fill={this.props.hexColors[HexUtils.getID(hex)]}
-        tutorialStep={this.props.tutorialStep}
-        hovered={this.props.hoveredHexId === HexUtils.getID(hex)}
-        isGameOver={this.props.isGameOver}
-      />
-    ));
+    const { actions, hexColors, hoveredHexId, isGameOver, layout, pieces, tutorialStep } = this.props;
+    return this.props.hexagons.map((hex, index) => {
+      const hexID = HexUtils.getID(hex);
+      return (
+        <HexShape
+          key={index}
+          hex={hex}
+          card={pieces[hexID]?.card}
+          stats={pieces[hexID]?.stats}
+          abilities={pieces[hexID]?.abilities}
+          triggers={pieces[hexID]?.triggers}
+          layout={layout}
+          actions={actions}
+          fill={hexColors[hexID]}
+          tutorialStep={tutorialStep}
+          hovered={hoveredHexId === hexID}
+          isGameOver={isGameOver}
+        />
+      );
+    });
   }
 
   private renderPieces(): JSX.Element {

--- a/src/common/components/hexgrid/HexShape.tsx
+++ b/src/common/components/hexgrid/HexShape.tsx
@@ -19,8 +19,15 @@ interface HexShapeProps {
 
   fill?: string
   card?: w.CardInGame
-  tutorialStep?: w.TutorialStep
+  stats?: {
+    attack?: number
+    health: number
+    speed?: number
+  }
+  abilities?: w.PassiveAbility[]
+  triggers?: w.TriggeredAbility[]
   activatedAbilities?: w.ActivatedAbility[]
+  tutorialStep?: w.TutorialStep
   selected?: boolean
   hovered?: boolean
   isGameOver?: boolean
@@ -84,7 +91,7 @@ export default class HexShape extends React.Component<HexShapeProps, HexShapeSta
   }
 
   public render(): JSX.Element {
-    const { actions, activatedAbilities, card, isGameOver, tutorialStep } = this.props;
+    const { actions, activatedAbilities, card, stats, abilities, triggers, isGameOver, tutorialStep } = this.props;
     const { displayTooltip } = this.state;
 
     if (this.shouldRenderTutorialTooltip) {
@@ -111,8 +118,15 @@ export default class HexShape extends React.Component<HexShapeProps, HexShapeSta
         </AbilitiesTooltip>
       );
     } else if (card) {
-     return (
-        <CardTooltip popover card={card} isOpen={displayTooltip}>
+      return (
+        <CardTooltip
+          popover
+          isOpen={displayTooltip}
+          card={card}
+          stats={stats}
+          abilities={abilities}
+          triggers={triggers}
+        >
           {this.renderHex()}
         </CardTooltip>
       );

--- a/src/common/components/hexgrid/types.d.ts
+++ b/src/common/components/hexgrid/types.d.ts
@@ -35,9 +35,12 @@ export interface PieceOnBoard {
   stats: {
     health: number
     attack?: number
+    speed?: number
     movesUsed?: number
     movesAvailable?: number
   }
+  abilities: w.PassiveAbility[]
+  triggers: w.TriggeredAbility[]
   attacking: w.HexId | null
   isDamaged: boolean
 }

--- a/src/common/reducers/handlers/game/cards.ts
+++ b/src/common/reducers/handlers/game/cards.ts
@@ -4,7 +4,7 @@ import HexUtils from '../../../components/hexgrid/HexUtils';
 import { TYPE_EVENT } from '../../../constants';
 import * as g from '../../../guards';
 import * as w from '../../../types';
-import { assertCardVisible, splitSentences } from '../../../util/cards';
+import { assertCardVisible, quoteKeywords, splitSentences } from '../../../util/cards';
 import { id } from '../../../util/common';
 import {
   allHexIds, applyAbilities, checkVictoryConditions, currentPlayer,
@@ -105,7 +105,7 @@ export function afterObjectPlayed(state: State, playedObject: w.Object): State {
 
   if (card.abilities && card.abilities.length > 0) {
     card.abilities.forEach((cmd, idx) => {
-      const cmdText = splitSentences(card.text || '')[idx];
+      const cmdText = quoteKeywords(splitSentences(card.text || '')[idx]);
       state.currentCmdText = cmdText.includes('"') ? cmdText.split('"')[1].replace(/"/g, '') : cmdText;
       executeCmd(state, cmd, playedObject);
     });

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -380,14 +380,17 @@ export interface PassiveAbility {
   onlyExecuteOnce?: boolean
   source?: AbilityId
   targets: StringRepresentationOf<(state: GameState) => Target>
+  text: string | null
   unapply: (target: Targetable) => void
 }
 
 export interface TriggeredAbility {
-  action: (state: GameState) => unknown
+  action: ((state: GameState) => unknown) | StringRepresentationOf<(state: GameState) => unknown>
   duration?: number
+  override?: boolean
   object?: _Object
   source?: AbilityId
+  text: string | null
   trigger: Trigger
 }
 

--- a/src/common/util/CardTextExampleStore.ts
+++ b/src/common/util/CardTextExampleStore.ts
@@ -21,8 +21,8 @@ export default class CardTextExampleStore {
     }
   }
 
-  public loadExamples = (sentences: string[], numToTry: number): Promise<any> => {
-    const candidates = shuffle(sentences).map(capitalize).map(expandKeywords).slice(0, numToTry);
+  public loadExamples = (sentences: string[], numToTry: number): Promise<void[]> => {
+    const candidates = shuffle(sentences).map(capitalize).map((s) => expandKeywords(s)).slice(0, numToTry);
     const modes = Object.keys(this.examples);
 
     return Promise.all(modes.map(async (mode) => {

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -375,9 +375,9 @@ export function keywordsInSentence(sentence: string, hintsToo = false): { [keywo
   }
 }
 
-export function expandKeywords(sentence: string): string {
+export function expandKeywords(sentence: string, quote = false): string {
   const keywords = keywordsInSentence(sentence);
-  return reduce(keywords, (str, def, keyword) => str.replace(keyword, def), sentence);
+  return reduce(keywords, (str, def, keyword) => str.replace(keyword, quote ? `"${def}"` : def), sentence);
 }
 
 export function contractKeywords(sentence: string): string {
@@ -386,6 +386,11 @@ export function contractKeywords(sentence: string): string {
     str.replace(`"${def}"`, capitalize(keyword))
        .replace(def, capitalize(keyword))
   ), sentence);
+}
+
+// e.g. 'All robots have Jump' => 'All robots have "Jump";
+export function quoteKeywords(sentence: string): string {
+  return contractKeywords(expandKeywords(sentence, true));
 }
 
 //

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -388,7 +388,7 @@ export function contractKeywords(sentence: string): string {
   ), sentence);
 }
 
-// e.g. 'All robots have Jump' => 'All robots have "Jump";
+// e.g. 'All robots have Jump' => 'All robots have "Jump"';
 export function quoteKeywords(sentence: string): string {
   return contractKeywords(expandKeywords(sentence, true));
 }

--- a/src/common/util/common.ts
+++ b/src/common/util/common.ts
@@ -1,4 +1,4 @@
-import {clamp as _clamp, fromPairs, isEqual, isNaN, isObject, isString, isUndefined, some} from 'lodash';
+import {clamp as _clamp, fromPairs, isEqual, isNaN, isObject, isString, isUndefined, last, some} from 'lodash';
 
 import * as w from '../types';
 
@@ -87,4 +87,12 @@ export function withoutEmptyFields<T extends Record<string, any>>(obj: T): T {
       (newObjSoFar, [k, v]) => Object.assign({}, newObjSoFar , { [k]: isObject(v) ? withoutEmptyFields(v) : v }),
       {} as T
     );
+}
+
+export function withTrailingPeriod(sentence: string | null): string {
+  if (sentence && sentence.length > 0 && last(sentence) !== '.') {
+    return `${sentence}.`;
+  } else {
+    return sentence || '';
+  }
 }

--- a/src/common/vocabulary/abilities.ts
+++ b/src/common/vocabulary/abilities.ts
@@ -6,15 +6,16 @@ import { id } from '../util/common';
 import { executeCmd, reversedCmd } from '../util/game';
 
 export function setAbility(state: w.GameState, currentObject: w.Object | null, source: w.AbilityId | null): w.Returns<void> {
-  return (ability) => {
+  return (ability: Omit<w.PassiveAbility, 'text'>) => {
     if (currentObject && (!source || !currentObject.abilities.find((a) => a.source === source))) {
-      ability = {
+      const finalizedAbility: w.PassiveAbility = {
         ...ability,
-        source,
-        duration: state.memory.duration || null
+        source: source || undefined,
+        duration: (state.memory.duration as number | undefined) || undefined,
+        text: state.currentCmdText || null
       };
 
-      currentObject.abilities = currentObject.abilities.concat([ability]);
+      currentObject.abilities = currentObject.abilities.concat([finalizedAbility]);
     }
   };
 }
@@ -37,7 +38,7 @@ export function unsetAbility(_state: w.GameState, currentObject: w.Object | null
 //   unapply => function that "un-applies" the ability from a target that is no longer valid
 //   onlyExecuteOnce => if true, the given ability will be disabled after executing once
 
-export function abilities(state: w.GameState): Record<string, w.Returns<w.PassiveAbility>> {
+export function abilities(state: w.GameState): Record<string, w.Returns<Omit<w.PassiveAbility, 'text'>>> {
   return {
     activated: (targetFunc: (s: w.GameState) => w.Target[], action) => {
       const aid: w.AbilityId = id();

--- a/src/common/vocabulary/triggers.ts
+++ b/src/common/vocabulary/triggers.ts
@@ -8,13 +8,14 @@ export function setTrigger(state: w.GameState, currentObject: w.Object | null, s
       isEqual(omit(t1.trigger, ['targets']), omit(t2.trigger, ['targets']));
   }
 
-  return (trigger: w.Trigger, action: w.Returns<void>, props = {}): void => {
+  return (trigger: w.Trigger, action: w.Returns<void>, props: Partial<w.TriggeredAbility> = {}): void => {
     const triggerObj: w.TriggeredAbility = {
       trigger,
       action: `(${action.toString()})`,
       override: false,
-      source,
-      duration: state.memory.duration || null,
+      source: source || undefined,
+      duration: (state.memory.duration as number | undefined) || undefined,
+      text: state.currentCmdText || null,
       ...props
     };
 

--- a/test/components/Board.spec.js
+++ b/test/components/Board.spec.js
@@ -36,6 +36,8 @@ describe('Board component', () => {
           'health': STARTING_PLAYER_HEALTH
         },
         'type': TYPE_CORE,
+        'abilities': [],
+        'triggers': [],
         'attacking': null,
         'isDamaged': false
       },
@@ -49,6 +51,8 @@ describe('Board component', () => {
           'health': STARTING_PLAYER_HEALTH
         },
         'type': TYPE_CORE,
+        'abilities': [],
+        'triggers': [],
         'attacking': null,
         'isDamaged': false
       }


### PR DESCRIPTION
[ close #1478, close #1516, close #1517 ]

For example, after playing some buffs on One Bot:
![image](https://user-images.githubusercontent.com/415965/120865379-c810f500-c542-11eb-8208-789f836d39b1.png)
