### PR TITLE
Disallow duplicate card names and renaming copy cards back to avoid confusion/misattribution

### DIFF
--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -98,9 +98,13 @@ export interface CardMetadata {
   source: CardSource
   created?: timestamp
   updated?: timestamp
-  duplicatedFrom?: CardId
   isPrivate?: boolean
   importedFromJson?: timestamp  // undefined if the card wasn't imported from JSON, otherwise the timestamp that the import happened
+  duplicatedFromCard?: {
+    id: CardId
+    name: string
+    metadata: CardMetadata
+  }
 }
 
 export interface CardSource {

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -445,7 +445,6 @@ export function normalizeCard(card: w.CardInStore, explicitSource?: w.CardSource
     ownerId: card.metadata?.ownerId || explicitSource?.uid || source.uid,
     source,
     updated: (card.metadata?.updated) || (card as any).timestamp,
-    duplicatedFrom: (card.metadata?.duplicatedFrom) || (source as any).duplicatedFrom,
     isPrivate: (card.metadata?.isPrivate) || false
   };
 

--- a/src/common/util/firebase.ts
+++ b/src/common/util/firebase.ts
@@ -189,7 +189,7 @@ export async function mostRecentCards(uid: w.UserId | null, limit: number): Prom
         && !!c.metadata.updated  // cards without timestamp (can't order them)
         && c.metadata.source.type === 'user'  // built-in cards
         && !c.metadata.isPrivate  // private cards
-        && !c.metadata.duplicatedFrom  // duplicated cards
+        && !c.metadata.duplicatedFromCard  // duplicated cards
         && !c.metadata.importedFromJson  // cards imported from JSON
         && (c.metadata.source.uid === c.metadata.ownerId)  // cards imported from other players' collections
     ),


### PR DESCRIPTION
[ fix #1507, fix #1525 ]