### PR TITLE
Support for triggers.afterAttackedBy + more functionality for triggers.afterDamageReceived

### DIFF
--- a/src/common/reducers/handlers/game/board.ts
+++ b/src/common/reducers/handlers/game/board.ts
@@ -147,18 +147,24 @@ export function attackComplete(state: State): State {
     const attackerAttack: number = getAttribute(attacker, 'attack') || 0;
     const defenderAttack: number = getAttribute(defender, 'attack') || 0;
 
+    state = triggerEvent(state, 'afterAttackedBy', {
+      object: defender,
+      condition: ((t) => !t.attackerType || stringToType(t.attackerType) === attacker.card.type || t.attackerType === 'allobjects'),
+      undergoer: attacker
+    });
+
     state = triggerEvent(state, 'afterAttack', {
       object: attacker,
       condition: ((t) => !t.defenderType || stringToType(t.defenderType) === defender.card.type || t.defenderType === 'allobjects'),
       undergoer: defender
     }, () => {
       defender.mostRecentlyInCombatWith = attacker;
-      return dealDamageToObjectAtHex(state, attackerAttack, target, 'combat');
+      return dealDamageToObjectAtHex(state, attackerAttack, target, attacker, 'combat');
     });
 
     if (!hasEffect(defender, 'cannotfightback') && defenderAttack > 0) {
       attacker.mostRecentlyInCombatWith = defender;
-      state = dealDamageToObjectAtHex(state, defenderAttack, source, 'combat');
+      state = dealDamageToObjectAtHex(state, defenderAttack, source, defender, 'combat');
     }
 
     // Move attacker to defender's space (if possible).

--- a/src/common/reducers/handlers/game/cards.ts
+++ b/src/common/reducers/handlers/game/cards.ts
@@ -95,7 +95,7 @@ export function instantiateObject(card: w.CardInGame): w.Object {
 }
 
 // This method is used to populate state.currentCmdText
-function getCommandTextForDisplay(cmdText: string) {
+function getCommandTextForDisplay(cmdText: string): string {
   // If cmdText is of the form `Some object gets "blah blah blah ability"` (i.e. exactly two " characters delimiting an ability),
   // pull out just the ability text that is quoted.
   if (cmdText.includes('"') && cmdText.split('"').length === 3) {

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -433,7 +433,9 @@ export interface Trigger {
 
   cardType?: string
   cause?: Cause
+  attackerType?: string
   defenderType?: string
+  damageSourceCardType?: string
 }
 
 export interface Attack {

--- a/src/common/vocabulary/actions.ts
+++ b/src/common/vocabulary/actions.ts
@@ -51,11 +51,11 @@ export default function actions(state: w.GameState, currentObject: w.Object | nu
       // Permanent attribute adjustment.
       iterateOver<w.Object | w.CardInGame>(objects)((object: w.Object | w.CardInGame) => {
         if (attr === 'allattributes') {
-          object.stats = mapValues(object.stats, clamp(func)) as {attack?: number, health: number, speed?: number};
+          Object.assign(object.stats, mapValues(object.stats, clamp(func)) as {attack?: number, health: number, speed?: number});
         } else if (attr === 'cost' && !g.isObject(object)) {
-          object.cost = clamp(func)((object ).cost);
+          object.cost = clamp(func)((object).cost);
         } else {
-          object.stats = applyFuncToFields(object.stats, func, isArray(attr) ? attr : [attr]);
+          Object.assign(object.stats, applyFuncToFields(object.stats, func, isArray(attr) ? attr : [attr]));
         }
       });
     }
@@ -111,7 +111,7 @@ export default function actions(state: w.GameState, currentObject: w.Object | nu
     dealDamage: (targets: w.ObjectOrPlayerCollection, amount: number): void => {
       iterateOver<w.Object>(targets)((target: w.Object) => {
         const hex = getHex(state, target)!;
-        dealDamageToObjectAtHex(state, amount, hex);
+        dealDamageToObjectAtHex(state, amount, hex, currentObject);
       });
     },
 

--- a/src/common/vocabulary/triggers.ts
+++ b/src/common/vocabulary/triggers.ts
@@ -36,64 +36,71 @@ export function unsetTrigger(_state: w.GameState, currentObject: w.Object | null
 export function triggers(_state: w.GameState): Record<string, w.Returns<w.Trigger>> {
   return {
     afterAttack: (targetFunc: (state: w.GameState) => w.Target[], defenderType: string): w.Trigger => ({
-        type: 'afterAttack',
-        defenderType,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterAttack',
+      defenderType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
+
+    afterAttackedBy: (targetFunc: (state: w.GameState) => w.Target[], attackerType: string): w.Trigger => ({
+      type: 'afterAttackedBy',
+      attackerType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterCardEntersDiscardPile: (targetFunc: (state: w.GameState) => w.Target[], cardType: string): w.Trigger => ({
-        type: 'afterCardEntersDiscardPile',
-        cardType,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterCardEntersDiscardPile',
+      cardType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterCardDraw: (targetFunc: (state: w.GameState) => w.Target[], cardType: string): w.Trigger => ({
-        type: 'afterCardDraw',
-        cardType,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterCardDraw',
+      cardType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterCardPlay: (targetFunc: (state: w.GameState) => w.Target[], cardType: string): w.Trigger => ({
-        type: 'afterCardPlay',
-        cardType,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterCardPlay',
+      cardType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
-    afterDamageReceived: (targetFunc: (state: w.GameState) => w.Target[]): w.Trigger => ({
-        type: 'afterDamageReceived',
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+    afterDamageReceived: (targetFunc: (state: w.GameState) => w.Target[], damageSourceCardType: string): w.Trigger => ({
+      type: 'afterDamageReceived',
+      damageSourceCardType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterDestroyed: (targetFunc: (state: w.GameState) => w.Target[], cause: w.Cause): w.Trigger => ({
-        type: 'afterDestroyed',
-        cause,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterDestroyed',
+      cause,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterDestroysOtherObject: (targetFunc: (state: w.GameState) => w.Target[], objectType: string): w.Trigger => ({
-        type: 'afterDestroysOtherObject',
-        cardType: objectType,
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterDestroysOtherObject',
+      cardType: objectType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterMove: (targetFunc: (state: w.GameState) => w.Target[]): w.Trigger => ({
-        type: 'afterMove',
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterMove',
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     afterPlayed: (targetFunc: (state: w.GameState) => w.Target[]): w.Trigger => ({
-        type: 'afterPlayed',
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'afterPlayed',
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     beginningOfTurn: (targetFunc: (state: w.GameState) => w.Target[]): w.Trigger => ({
-        type: 'beginningOfTurn',
-        targetFunc: `(${targetFunc.toString()})`
-      }),
+      type: 'beginningOfTurn',
+      targetFunc: `(${targetFunc.toString()})`
+    }),
 
     endOfTurn: (targetFunc: (state: w.GameState) => w.Target[]): w.Trigger => ({
-        type: 'endOfTurn',
-        targetFunc: `(${targetFunc.toString()})`
-      })
+      type: 'endOfTurn',
+      targetFunc: `(${targetFunc.toString()})`
+    })
   };
 }

--- a/test/data/cards.ts
+++ b/test/data/cards.ts
@@ -249,6 +249,21 @@ export const countdownClockCard: w.CardInStore = {
   },
 };
 
+export const drawerCard: w.CardInStore = {
+  metadata: { source: { type: 'user' } as w.CardSource },
+  id: 'Drawer',
+  name: 'Drawer',
+  text: 'Whenever a robot attacks this structure, draw a card.',
+  abilities: [
+    "(function () { setTrigger(triggers['afterAttackedBy'](function () { return targets['thisRobot'](); }, 'robot'), (function () { actions['draw'](targets['self'](), 1); })); })"
+  ],
+  cost: 1,
+  type: TYPE_STRUCTURE,
+  stats: {
+    health: 5,
+  },
+};
+
 export const rageCard: w.CardInStore = {
   metadata: { source: { type: 'user' } as w.CardSource },
   id: 'Rage',

--- a/test/vocabulary/triggers.spec.ts
+++ b/test/vocabulary/triggers.spec.ts
@@ -38,6 +38,22 @@ describe('[vocabulary.triggers]', () => {
       expect(queryObjectAttribute(state, '0,-1,1', 'health')).toEqual(2);
     });
 
+    it('should be able to activate afterAttackedBy triggered abilities', () => {
+      // Drawer: "Whenever a robot attacks this structure, draw a card.""
+      let state = setUpBoardState({
+        orange: {
+          '0,0,0': testCards.drawerCard
+        },
+        blue: {
+          '0,-1,1': cards.oneBotCard
+        }
+      });
+      state = newTurn(state, 'blue');
+      const orangeCardsInHand = state.players.orange.hand.length;
+      state = attack(state, '0,-1,1', '0,0,0');
+      expect(state.players.orange.hand.length).toEqual(orangeCardsInHand + 1);
+    });
+
     it('should be able to activate afterDamageReceived triggered abilities', () => {
       // Wisdom Bot: "Whenever this robot takes damage, draw a card."
       let state = setUpBoardState({


### PR DESCRIPTION
fix #1599, fix #1600

This is the client-facing side of https://github.com/wordbots/wordbots-parser/pull/200/files

TODO:
* [x] add unit test for `afterAttackedBy` to resolve coverage