### PR TITLE
Visual cues for object effects + bug fixes and improvements relating to abilities and effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,7 +194,6 @@
     ],
     "coverageThreshold": {
       "./src/common/vocabulary/**/*.ts": {
-        "statements": 100,
         "lines": 100
       }
     },

--- a/src/common/components/game/Board.tsx
+++ b/src/common/components/game/Board.tsx
@@ -1,7 +1,7 @@
 import { compact, forOwn, isString, mapValues } from 'lodash';
 import * as React from 'react';
 
-import { BLUE_PLACEMENT_HEXES, GRID_CONFIG, KEYWORDS, ORANGE_PLACEMENT_HEXES, TYPE_ROBOT, TYPE_STRUCTURE } from '../../constants';
+import { BLUE_PLACEMENT_HEXES, GRID_CONFIG, ORANGE_PLACEMENT_HEXES, TYPE_ROBOT, TYPE_STRUCTURE } from '../../constants';
 import defaultGameState, { bluePlayerState, orangePlayerState } from '../../store/defaultGameState';
 import * as w from '../../types';
 import { withTrailingPeriod } from '../../util/common';

--- a/src/common/components/game/Hand.tsx
+++ b/src/common/components/game/Hand.tsx
@@ -13,7 +13,8 @@ interface HandProps {
   selectedCard: number
   targetableCards: w.CardId[]
   status: w.PlayerStatus
-  isActivePlayer?: boolean
+  isCurrentPlayer: boolean
+  isActivePlayer: boolean
   curved?: boolean
   opponent?: boolean
   sandbox?: boolean
@@ -67,7 +68,7 @@ export default class Hand extends React.Component<HandProps, HandState> {
     // eslint-disable-next-line react/no-find-dom-node
     const node: HTMLElement | null = ReactDOM.findDOMNode(this) as HTMLElement | null;
     if (node) {
-      this.setState({availableWidth: node.offsetWidth});
+      this.setState({ availableWidth: node.offsetWidth });
     }
   }
 
@@ -75,7 +76,7 @@ export default class Hand extends React.Component<HandProps, HandState> {
 
   private renderCards(): JSX.Element[] {
     const {
-      cards, isActivePlayer, targetableCards, status, curved, opponent, sandbox, selectedCard, tutorialStep,
+      cards, isActivePlayer, isCurrentPlayer, targetableCards, status, curved, opponent, sandbox, selectedCard, tutorialStep,
       onSelectCard, onTutorialStep
     } = this.props;
     const { availableWidth, hoveredCardIdx } = this.state;
@@ -107,7 +108,7 @@ export default class Hand extends React.Component<HandProps, HandState> {
             idx={idx}
             margin={idx < numCards - 1 ? cardMargin : 0}
             rotation={isUpsideDown ? 180 : (curved ? rotationDegs : 0)}
-            selected={selectedCard === idx && (isEmpty(targetableCards) || !isActivePlayer)}
+            selected={selectedCard === idx && (!sandbox || isCurrentPlayer) && (isEmpty(targetableCards) || !isActivePlayer)}
             status={status}
             targetable={isActivePlayer && targetableCards.includes(card.id)}
             tutorialStep={tutorialStep}

--- a/src/common/components/game/PlayerArea.tsx
+++ b/src/common/components/game/PlayerArea.tsx
@@ -135,7 +135,8 @@ export default class PlayerArea extends React.Component<PlayerAreaProps, PlayerA
           opponent={opponent}
           selectedCard={gameProps.selectedCard!}
           targetableCards={gameProps.target.possibleCardsInHand}
-          isActivePlayer={gameProps.player === color || gameProps.isSandbox}
+          isCurrentPlayer={gameProps.currentTurn === color}
+          isActivePlayer={gameProps.player === color}
           cards={this.hand}
           sandbox={gameProps.isSandbox}
           status={gameProps.status}

--- a/src/common/components/hexgrid/HexGrid.tsx
+++ b/src/common/components/hexgrid/HexGrid.tsx
@@ -57,14 +57,14 @@ export default class HexGrid extends React.Component<HexShapeProps> {
         xmlns="http://www.w3.org/2000/svg"
       >
         {this.renderHexes()}
-        {this.renderPieces()}
         {this.renderSelectedHex()}
+        {this.renderPieces()}
         <defs>
           <filter id="dropShadow" width="5" x="-1" height="5" y="-1">
-            <feOffset in="SourceAlpha" dx="0.5" dy="0.5" result="offset"/>
-            <feGaussianBlur in="offset" stdDeviation="0.5" result="blur"/>
-            <feFlood floodColor="#3D4574" floodOpacity="0.5" result="offsetColor"/>
-            <feComposite in="offsetColor" in2="blur" operator="in" result="blended"/>
+            <feOffset in="SourceAlpha" dx="0.5" dy="0.5" result="offset" />
+            <feGaussianBlur in="offset" stdDeviation="0.5" result="blur" />
+            <feFlood floodColor="#3D4574" floodOpacity="0.5" result="offsetColor" />
+            <feComposite in="offsetColor" in2="blur" operator="in" result="blended" />
             <feBlend in="SourceGraphic" in2="blended" />
           </filter>
         </defs>

--- a/src/common/components/hexgrid/HexPiece.tsx
+++ b/src/common/components/hexgrid/HexPiece.tsx
@@ -1,7 +1,7 @@
 import { compact, isUndefined, times } from 'lodash';
 import * as React from 'react';
 
-import { ANIMATION_TIME_MS, TYPE_CORE } from '../../constants';
+import { ANIMATION_TIME_MS, EFFECT_ICONS, TYPE_CORE } from '../../constants';
 
 import Hex from './Hex';
 import HexUtils from './HexUtils';
@@ -144,28 +144,7 @@ export default class HexPiece extends React.Component<HexPieceProps> {
 
 
   private renderPieceEffects(): JSX.Element {
-    const icons = {
-      'canmoveoverobjects': '', // ra-feather-wing
-      'cannotactivate': '', // ra-hand-emblem
-      'cannotattack': '', // ra-shield
-      'cannotfightback': '', // ra-broken-shield
-      'cannotmove': '', // ra-falling
-      'cannotmoveto': '', // ra-player-teleport
-      'canonlyattack': '', // ra-aware
-      'taunt': '', // ra-muscle-fat
-    };
-
-    const tooltips = {
-      'canmoveoverobjects': 'Jump (This robot can move over other objects.)', // ra-feather-wing
-      'cannotactivate': 'This robot can\t activate abilities.', // ra-hand-emblem
-      'cannotattack': 'Defender (This robot can\'t attack.)', // ra-shield
-      'cannotfightback': 'This robot can\'t fight back when attacked.', // ra-broken-shield
-      'cannotmove': 'This robot can\'t move.', // ra-falling
-      'cannotmoveto': 'This robot cannot move to certain hexes.', // ra-player-teleport
-      'canonlyattack': 'This robot can only attack certain objects.', // ra-aware
-      'taunt': 'Taunt (Your opponent\'s adjacent robots can only attack this object.)', // ra-muscle-fat
-    };
-
+    // Coordinates of effect icon "slots", starting from the first (alphabetically last) effect icon.
     const coords = [
       [0, -5.5],
       [2, -4.5],
@@ -185,12 +164,12 @@ export default class HexPiece extends React.Component<HexPieceProps> {
       <g>
         {
           compact(effects.sort().reverse().map((effectName, idx) => {
-            const icon = icons[effectName];
+            const { icon, description } = EFFECT_ICONS[effectName];
             if (icon) {
               return (
                 <text key={effectName} x={coords[idx][0]} y={coords[idx][1]} textAnchor="middle" style={{ fontSize: '0.12em' }} className="ra">
                   {icon}
-                  <title>{tooltips[effectName]}</title>
+                  <title>{description}</title>
                 </text>
               );
             } else {

--- a/src/common/components/hexgrid/HexPiece.tsx
+++ b/src/common/components/hexgrid/HexPiece.tsx
@@ -1,4 +1,4 @@
-import { isUndefined, times } from 'lodash';
+import { compact, isUndefined, times } from 'lodash';
 import * as React from 'react';
 
 import { ANIMATION_TIME_MS, TYPE_CORE } from '../../constants';
@@ -70,6 +70,7 @@ export default class HexPiece extends React.Component<HexPieceProps> {
           className={`hex-piece ${piece.type === TYPE_CORE && 'kernel'} ${piece.isDamaged && 'piece-damage'}`}
         />
         {this.renderPieceStats()}
+        {this.renderPieceEffects()}
       </g>
     );
   }
@@ -93,7 +94,7 @@ export default class HexPiece extends React.Component<HexPieceProps> {
     const value = this.props.piece.stats[stat];
     const isLargeNumber = value && value >= 20;
 
-    const xPos = {attack: -3, health: 3}[stat];
+    const xPos = { attack: -3, health: 3 }[stat];
     const textStyle = {
       fontFamily: '"Carter One", "Carter One-fallback"',
       fontSize: isLargeNumber ? '0.14em' : '0.18em',
@@ -101,7 +102,7 @@ export default class HexPiece extends React.Component<HexPieceProps> {
       fillOpacity: 1
     };
     const circleStyle = {
-      fill: {attack: '#E57373', health: '#81C784'}[stat],
+      fill: { attack: '#E57373', health: '#81C784' }[stat],
       strokeWidth: 0.2,
       stroke: '#777'
     };
@@ -117,7 +118,7 @@ export default class HexPiece extends React.Component<HexPieceProps> {
   }
 
   private renderSpeedStat(): JSX.Element | null {
-    const { movesUsed, movesAvailable }  = this.props.piece.stats;
+    const { movesUsed, movesAvailable } = this.props.piece.stats;
 
     if (movesUsed === undefined || movesAvailable === undefined) {
       return null;
@@ -137,6 +138,66 @@ export default class HexPiece extends React.Component<HexPieceProps> {
     return (
       <g key="speed">
         <text x="0" y="6" textAnchor="middle" style={wrapperStyle}>{movesAvailableDots}{movesUsedDots}</text>
+      </g>
+    );
+  }
+
+
+  private renderPieceEffects(): JSX.Element {
+    const icons = {
+      'canmoveoverobjects': '', // ra-feather-wing
+      'cannotactivate': '', // ra-hand-emblem
+      'cannotattack': '', // ra-shield
+      'cannotfightback': '', // ra-broken-shield
+      'cannotmove': '', // ra-falling
+      'cannotmoveto': '', // ra-player-teleport
+      'canonlyattack': '', // ra-aware
+      'taunt': '', // ra-muscle-fat
+    };
+
+    const tooltips = {
+      'canmoveoverobjects': 'Jump (This robot can move over other objects.)', // ra-feather-wing
+      'cannotactivate': 'This robot can\t activate abilities.', // ra-hand-emblem
+      'cannotattack': 'Defender (This robot can\'t attack.)', // ra-shield
+      'cannotfightback': 'This robot can\'t fight back when attacked.', // ra-broken-shield
+      'cannotmove': 'This robot can\'t move.', // ra-falling
+      'cannotmoveto': 'This robot cannot move to certain hexes.', // ra-player-teleport
+      'canonlyattack': 'This robot can only attack certain objects.', // ra-aware
+      'taunt': 'Taunt (Your opponent\'s adjacent robots can only attack this object.)', // ra-muscle-fat
+    };
+
+    const coords = [
+      [0, -5.5],
+      [2, -4.5],
+      [-2, -4.5],
+      [4, -3.5],
+      [-4, -3.5],
+      [6, -2.5],
+      [-6, -2.5],
+      [8, -1.5],
+      [-8, -1.5],
+    ];
+
+    const { effects } = this.props.piece;
+
+    // Note that we reverse-sort the effects, just so Taunt is always at the top of the hierarchy (if present).
+    return (
+      <g>
+        {
+          compact(effects.sort().reverse().map((effectName, idx) => {
+            const icon = icons[effectName];
+            if (icon) {
+              return (
+                <text key={effectName} x={coords[idx][0]} y={coords[idx][1]} textAnchor="middle" style={{ fontSize: '0.12em' }} className="ra">
+                  {icon}
+                  <title>{tooltips[effectName]}</title>
+                </text>
+              );
+            } else {
+              return null;
+            }
+          }))
+        }
       </g>
     );
   }

--- a/src/common/components/hexgrid/HexPiece.tsx
+++ b/src/common/components/hexgrid/HexPiece.tsx
@@ -1,4 +1,4 @@
-import { compact, isUndefined, times } from 'lodash';
+import { isUndefined, times, uniq } from 'lodash';
 import * as React from 'react';
 
 import { ANIMATION_TIME_MS, EFFECT_ICONS, TYPE_CORE } from '../../constants';
@@ -16,6 +16,19 @@ interface HexPieceProps {
   actions: Actions
   piece: PieceOnBoard
 }
+
+// Coordinates of effect icon "slots", starting from the first (alphabetically last) effect icon.
+const PIECE_EFFECT_SLOT_COORDS = [
+  [0, -5.5],
+  [2, -4.5],
+  [-2, -4.5],
+  [6, -2.5],
+  [4, -3.5],
+  [-4, -3.5],
+  [-6, -2.5],
+  [8, -1.5],
+  [-8, -1.5],
+];
 
 export default class HexPiece extends React.Component<HexPieceProps> {
   // actual hex coords of the piece
@@ -143,41 +156,21 @@ export default class HexPiece extends React.Component<HexPieceProps> {
   }
 
 
-  private renderPieceEffects(): JSX.Element {
-    // Coordinates of effect icon "slots", starting from the first (alphabetically last) effect icon.
-    const coords = [
-      [0, -5.5],
-      [2, -4.5],
-      [-2, -4.5],
-      [4, -3.5],
-      [-4, -3.5],
-      [6, -2.5],
-      [-6, -2.5],
-      [8, -1.5],
-      [-8, -1.5],
-    ];
-
-    const { effects } = this.props.piece;
-
-    // Note that we reverse-sort the effects, just so Taunt is always at the top of the hierarchy (if present).
-    return (
-      <g>
-        {
-          compact(effects.sort().reverse().map((effectName, idx) => {
-            const { icon, description } = EFFECT_ICONS[effectName];
-            if (icon) {
-              return (
-                <text key={effectName} x={coords[idx][0]} y={coords[idx][1]} textAnchor="middle" style={{ fontSize: '0.12em' }} className="ra">
-                  {icon}
-                  <title>{description}</title>
-                </text>
-              );
-            } else {
-              return null;
-            }
-          }))
-        }
-      </g>
-    );
-  }
+  private renderPieceEffects = (): JSX.Element => (
+    <g>
+      {
+        // Note that we reverse-sort the effects, just so Taunt is always at the top of the hierarchy (if present).
+        uniq(this.props.piece.effects).sort().reverse().map((effectName, idx) => {
+          const { icon, description } = EFFECT_ICONS[effectName];
+          const [x, y] = PIECE_EFFECT_SLOT_COORDS[idx];
+          return (
+            <text key={effectName} x={x} y={y} textAnchor="middle" style={{ fontSize: '0.12em' }} className="ra">
+              {icon}
+              <title>{description}</title>
+            </text>
+          );
+        })
+      }
+    </g>
+  );
 }

--- a/src/common/components/hexgrid/types.d.ts
+++ b/src/common/components/hexgrid/types.d.ts
@@ -43,4 +43,5 @@ export interface PieceOnBoard {
   triggers: w.TriggeredAbility[]
   attacking: w.HexId | null
   isDamaged: boolean
+  effects: Array<w.EffectType | 'taunt'>
 }

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -13,7 +13,7 @@ export const LOG_SOCKET_IO = false;
 export const KEEP_DECKS_UNSHUFFLED = false;
 export const DISABLE_TURN_TIMER = false;
 export const DISABLE_AI = false;
-export const DISPLAY_HEX_IDS = true;
+export const DISPLAY_HEX_IDS = false;
 export const ENABLE_REDUX_TIME_TRAVEL = false;
 
 // Server settings.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -219,3 +219,40 @@ export const ORANGE_PLAYER_COLOR = '#ffb85d';
 export const ORANGE_PLAYER_COLOR_DARKENED = '#d99237';
 export const BLUE_PLAYER_COLOR = '#badbff';
 export const BLUE_PLAYER_COLOR_DARKENED = '#94b5d9';
+
+// Effect icons.
+
+export const EFFECT_ICONS: Record<string, { icon: string, description: string }> = {
+  'canmoveoverobjects': {
+    icon: '', // ra-feather-wing
+    description: 'Jump (This robot can move over other objects.)'
+  },
+  'cannotactivate': {
+    icon: '', // ra-hand-emblem
+    description: 'This object can\t activate abilities.'
+  },
+  'cannotattack': {
+    icon: '', // ra-shield
+    description: 'Defender (This robot can\'t attack.)'
+  },
+  'cannotfightback': {
+    icon: '', // ra-broken-shield
+    description: 'This object can\'t fight back when attacked.'
+  },
+  'cannotmove': {
+    icon: '', // ra-falling
+    description: 'This robot can\'t move.'
+  },
+  'cannotmoveto': {
+    icon: '', // ra-player-teleport
+    description: 'This robot cannot move to certain hexes.'
+  },
+  'canonlyattack': {
+    icon: '', // ra-aware
+    description: 'This robot can only attack certain objects.'
+  },
+  'taunt': {
+    icon: '', // ra-muscle-fat
+    description: 'Taunt (Your opponent\'s adjacent robots can only attack this object.)'
+  },
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -13,7 +13,7 @@ export const LOG_SOCKET_IO = false;
 export const KEEP_DECKS_UNSHUFFLED = false;
 export const DISABLE_TURN_TIMER = false;
 export const DISABLE_AI = false;
-export const DISPLAY_HEX_IDS = false;
+export const DISPLAY_HEX_IDS = true;
 export const ENABLE_REDUX_TIME_TRAVEL = false;
 
 // Server settings.

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -103,7 +103,7 @@ export const GRID_CONFIG: GridConfig = {
   layout: { width: 6, height: 6, flat: false, spacing: 0 },
   origin: { x: 0, y: 0 },
   map: 'hexagon',
-  mapProps: [ 3 ]
+  mapProps: [3]
 };
 
 export const BOARD_SIZE_MULTIPLIER = 1.35;

--- a/src/common/containers/Help.tsx
+++ b/src/common/containers/Help.tsx
@@ -3,8 +3,9 @@ import Paper from '@material-ui/core/Paper';
 import { Location } from 'history';
 import * as React from 'react';
 import Helmet from 'react-helmet';
+import { sortBy } from 'lodash';
 
-import { HEADER_HEIGHT } from '../constants';
+import { EFFECT_ICONS, HEADER_HEIGHT } from '../constants';
 import AnchorLink, { helpPageScrollerId } from '../components/help/AnchorLink';
 import Background from '../components/Background';
 import MarkdownBlock from '../components/MarkdownBlock';
@@ -37,6 +38,8 @@ const Help = (): JSX.Element => (
         <AnchorLink id="formats">Formats</AnchorLink>
         &nbsp;&bull;&nbsp;
         <AnchorLink id="modes">Modes</AnchorLink>
+        &nbsp;&bull;&nbsp;
+        <AnchorLink id="effects">Effect Icons</AnchorLink>
         &nbsp;&bull;&nbsp;
         <AnchorLink id="parser-help">Parser Help</AnchorLink>
       </Paper>
@@ -91,6 +94,17 @@ const Help = (): JSX.Element => (
                 Control both players and play any Wordbots card you&rsquo;d like.
                 Sandbox mode is especially useful for testing out cards you&rsquo;re building in the Workshop.
               </li>
+            </ul>
+          </HelpSection>
+          <HelpSection id="effects" title="Effect Icons">
+            <p><i>Effect icons</i> are little in-game indicators of certain statuses pertaining to objects on the board:</p>
+            <ul>
+              {sortBy(Object.values(EFFECT_ICONS), 'description').map(({ icon, description }) => (
+                <li key={description}>
+                  <span className="ra" style={{ position: 'relative', top: 2, fontSize: 16, lineHeight: 1.2 }}>{icon}</span>:{' '}
+                  {description}
+                </li>
+              ))}
             </ul>
           </HelpSection>
         </div>

--- a/src/common/guards.ts
+++ b/src/common/guards.ts
@@ -22,6 +22,10 @@ export function isObjectCollection(collection: w.Collection): collection is w.Ob
   return entries.every(isObject);
 }
 
+export function isCardInHandCollection(collection: w.Collection): collection is w.CardInHandCollection {
+  return collection.type === 'cards';
+}
+
 export function isCardObfuscated(target: w.PossiblyObfuscatedCard): target is w.ObfuscatedCard {
   return (target as w.CardInGame).name === undefined;
 }

--- a/src/common/guards.ts
+++ b/src/common/guards.ts
@@ -17,13 +17,16 @@ export function isPlayerState(target: w.Targetable): target is w.PlayerInGameSta
   return !isNil(target) && (target as w.PlayerInGameState).objectsOnBoard !== undefined;
 }
 
-export function isObjectCollection(collection: w.Collection): collection is w.ObjectCollection {
-  const entries = collection.entries as w.Object[];
-  return entries.every(isObject);
+export function isCardCollection(collection: w.Collection): collection is w.CardCollection {
+  return collection.type === 'cards' || collection.type === 'cardsInDiscardPile';
 }
 
-export function isCardInHandCollection(collection: w.Collection): collection is w.CardInHandCollection {
-  return collection.type === 'cards';
+export function isObjectCollection(collection: w.Collection): collection is w.ObjectCollection {
+  return collection.type === 'objects';
+}
+
+export function isPlayerCollection(collection: w.Collection): collection is w.PlayerCollection {
+  return collection.type === 'players';
 }
 
 export function isCardObfuscated(target: w.PossiblyObfuscatedCard): target is w.ObfuscatedCard {

--- a/src/common/reducers/handlers/game/cards.ts
+++ b/src/common/reducers/handlers/game/cards.ts
@@ -27,9 +27,9 @@ export function setSelectedCard(state: State, playerName: w.PlayerColor, cardIdx
   player.selectedTile = null;
 
   if (isCurrentPlayer &&
-      player.target.choosing &&
-      player.target.possibleCardsInHand.includes(selectedCard.id) &&
-      (player.selectedCard !== null || state.callbackAfterTargetSelected !== null)) {
+    player.target.choosing &&
+    player.target.possibleCardsInHand.includes(selectedCard.id) &&
+    (player.selectedCard !== null || state.callbackAfterTargetSelected !== null)) {
     // Target chosen for a queued action.
     return setTargetAndExecuteQueuedAction(state, assertCardVisible(selectedCard));
   } else if (player.selectedCard === cardIdx) {
@@ -64,10 +64,10 @@ export function setSelectedCardInDiscardPile(state: State, playerName: w.PlayerC
   player.selectedTile = null;
 
   if (isCurrentPlayer &&
-      player.target.choosing &&
-      selectedCard &&
-      player.target.possibleCardsInDiscardPile.includes(selectedCard.id) &&
-      (player.selectedCard !== null || state.callbackAfterTargetSelected !== null)) {
+    player.target.choosing &&
+    selectedCard &&
+    player.target.possibleCardsInDiscardPile.includes(selectedCard.id) &&
+    (player.selectedCard !== null || state.callbackAfterTargetSelected !== null)) {
     // Target chosen for a queued action.
     return setTargetAndExecuteQueuedAction(state, selectedCard);
   }
@@ -82,15 +82,16 @@ export function instantiateObject(card: w.CardInGame): w.Object {
     card,
     type: card.type,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    stats: {...card.stats!},
+    stats: { ...card.stats! },
     triggers: [],
     abilities: [],
+    effects: [],
     movesMade: 0,
     cantMove: true,
     cantAttack: true,
     cantActivate: true,
     justPlayed: true  // This flag is needed to, e.g. prevent objects from being able to
-                      // target themselves for afterPlayed triggers.
+    // target themselves for afterPlayed triggers.
   };
 }
 
@@ -113,7 +114,7 @@ export function afterObjectPlayed(state: State, playedObject: w.Object): State {
   const timestamp = Date.now();
 
   state = triggerSound(state, 'spawn.wav');
-  state = logAction(state, player, `played |${card.id}|`, {[card.id]: card}, timestamp, target);
+  state = logAction(state, player, `played |${card.id}|`, { [card.id]: card }, timestamp, target);
   state.memory = {};  // Clear any previously set memory in the state.
 
   if (card.abilities && card.abilities.length > 0) {
@@ -124,7 +125,7 @@ export function afterObjectPlayed(state: State, playedObject: w.Object): State {
     });
   }
 
-  state = triggerEvent(state, 'afterPlayed', {object: playedObject});
+  state = triggerEvent(state, 'afterPlayed', { object: playedObject });
 
   playedObject.justPlayed = false;
 
@@ -140,7 +141,7 @@ export function placeCard(state: State, cardIdx: number, tile: w.HexId): State {
   const card: w.CardInGame = assertCardVisible(player.hand[cardIdx]);
 
   if ((player.energy.available >= getCost(card) || state.sandbox) &&
-      validPlacementHexes(state, player.color, card.type).map(HexUtils.getID).includes(tile)) {
+    validPlacementHexes(state, player.color, card.type).map(HexUtils.getID).includes(tile)) {
     const playedObject: w.Object = instantiateObject(card);
 
     player.objectsOnBoard[tile] = playedObject;
@@ -197,7 +198,7 @@ function playEvent(state: State, cardIdx: number): State {
     const target = player.target.chosen ? player.target.chosen[0] : null;
 
     tempState = triggerSound(tempState, 'event.wav');
-    tempState = logAction(tempState, player, `played |${card.id}|`, {[card.id]: card}, timestamp, player.target.choosing && target || null);
+    tempState = logAction(tempState, player, `played |${card.id}|`, { [card.id]: card }, timestamp, player.target.choosing && target || null);
     tempState.eventExecuting = true;
     tempState.memory = {};  // Clear any previously set memory in the state.
 
@@ -217,21 +218,21 @@ function playEvent(state: State, cardIdx: number): State {
       state.callbackAfterTargetSelected = ((newState: State) => playEvent(newState, cardIdx));
       currentPlayer(state).selectedCard = cardIdx;
       currentPlayer(state).target = player.target;
-      currentPlayer(state).status = {message: `Choose a target for ${card.name}.`, type: 'text'};
+      currentPlayer(state).status = { message: `Choose a target for ${card.name}.`, type: 'text' };
     } else if (tempState.invalid) {
       // Temp state is invalid (e.g. no valid target available or player unable to pay an energy cost).
       // So return the old state.
       // This must come after the `choosing` case to allow multiple target selection,
       // but *before* the `!chosen` case to correctly handle the case where no target is available.
       currentPlayer(state).selectedCard = cardIdx;
-      currentPlayer(state).status = {message: `Unable to play ${card.name}!`, type: 'error'};
+      currentPlayer(state).status = { message: `Unable to play ${card.name}!`, type: 'error' };
     } else if (!player.target.chosen) {
       // If there is no target selection, that means that this card is a global effect.
       // In that case, the player needs to "target" the board to confirm that they want to play the event.
       state.callbackAfterTargetSelected = ((newState: State) => playEvent(newState, cardIdx));
       currentPlayer(state).selectedCard = cardIdx;
       currentPlayer(state).target = { choosing: true, chosen: null, possibleCardsInHand: [], possibleCardsInDiscardPile: [], possibleHexes: allHexIds() };
-      currentPlayer(state).status = {message: `Click anywhere on the board to play ${card.name}.`, type: 'text'};
+      currentPlayer(state).status = { message: `Click anywhere on the board to play ${card.name}.`, type: 'text' };
     } else {
       // Everything is good (valid state + no more targets to select), so we can return the new state!
       card.justPlayed = false;

--- a/src/common/reducers/handlers/game/cards.ts
+++ b/src/common/reducers/handlers/game/cards.ts
@@ -38,13 +38,14 @@ export function setSelectedCard(state: State, playerName: w.PlayerColor, cardIdx
     player.status.message = '';
     player.target.choosing = false;
   } else if (isCurrentPlayer) {
+    player.target.choosing = false; // Reset targeting state.
+
     // Try to play the chosen card.
     if (g.isCardVisible(selectedCard) && (getCost(selectedCard) <= energy.available || state.sandbox)) {
       if (selectedCard.type === TYPE_EVENT) {
         return playEvent(state, cardIdx);
       } else {
         player.selectedCard = cardIdx;
-        player.target.choosing = false; // Reset targeting state.
         player.status = { type: 'text', message: 'Select an available tile to play this card.' };
       }
     } else {

--- a/src/common/store/defaultGameState.ts
+++ b/src/common/store/defaultGameState.ts
@@ -42,10 +42,11 @@ function playerState(
         id: `${color}Core`,
         type: TYPE_CORE,
         card: coreCard,
-        stats: {...coreCard.stats} as { health: number },
+        stats: { ...coreCard.stats } as { health: number },
         movesMade: 0,
         triggers: [],
         abilities: [],
+        effects: [],
         tookDamageThisTurn: false
       }
     },

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -364,7 +364,7 @@ interface _Object { // eslint-disable-line @typescript-eslint/naming-convention
   triggers: TriggeredAbility[]
   abilities: PassiveAbility[]
   activatedAbilities?: ActivatedAbility[]
-  effects?: Effect[]
+  effects: Effect[]
 
   cantActivate?: boolean
   cantAttack?: boolean
@@ -409,7 +409,7 @@ export interface ActivatedAbility {
 export interface PassiveAbility {
   aid: AbilityId
   apply: (target: Targetable) => void
-  currentTargets?: Target
+  currentTargets?: TargetReference
   disabled?: boolean
   duration?: number
   onlyExecuteOnce?: boolean
@@ -487,8 +487,9 @@ export interface ChatMessage {
 
 // Vocabulary types
 
-export type Collection = CardInHandCollection | CardInDiscardPileCollection | ObjectOrPlayerCollection | HexCollection;
+export type Collection = CardCollection | ObjectOrPlayerCollection | HexCollection;
 export type Target = Collection;  // Easier to not have to maintain separate types for Target vs Collection since they're conceptually interchangeable.
+export type CardCollection = CardInHandCollection | CardInDiscardPileCollection
 export type ObjectOrPlayerCollection = ObjectCollection | PlayerCollection;
 export interface CardInHandCollection {
   type: 'cards'
@@ -510,3 +511,19 @@ export interface HexCollection {
   type: 'hexes'
   entries: HexId[]
 }
+
+/** Internal types used to represent a reference that resolves to a `Target`. */
+export type TargetReference = CardsTargetRef | ObjectsTargetRef | PlayersTargetRef | HexesTargetRef;
+interface CardsTargetRef {
+  type: 'cardIds'
+  entries: CardId[]
+}
+interface ObjectsTargetRef {
+  type: 'objectIds'
+  entries: ObjectId[]
+}
+interface PlayersTargetRef {
+  type: 'playerIds'
+  entries: PlayerColor[]
+}
+type HexesTargetRef = HexCollection; // HexIds are just strings, so a HexCollection is its own reference.

--- a/src/common/util/game.ts
+++ b/src/common/util/game.ts
@@ -845,6 +845,7 @@ export function triggerEvent(
 }
 
 /** Given a Target, "refresh" its entries so that they point to "current" objects/cards if possible. */
+// TODO instead of this, we should actually track target IDs, not targets themselves, in ability.currentTargets
 function retarget(state: w.GameState, target: w.Target): w.Target {
   if (g.isObjectCollection(target)) {
     return {
@@ -870,6 +871,7 @@ export function applyAbilities(state: w.GameState): w.GameState {
       // Unapply this ability for all previously targeted objects.
       if (ability.currentTargets) {
         const targets: w.Targetable[] = retarget(state, ability.currentTargets).entries;
+        retarget(state, ability.currentTargets).entries;
         targets.forEach(ability.unapply);
       }
 

--- a/src/common/vocabulary/abilities.ts
+++ b/src/common/vocabulary/abilities.ts
@@ -123,6 +123,7 @@ export function abilities(state: w.GameState): Record<string, w.Returns<Omit<w.P
         targets: `(${targetFunc.toString()})`,
         apply: (target: w.Targetable) => {
           if (isObject(target)) {
+            //console.log(`${aid}: apply ${effect} to '${target.card.name}'`);
             if (!(target.effects || []).find((eff) => eff.aid === aid)) {
               target.effects = (target.effects || []).concat({
                 aid,
@@ -134,6 +135,7 @@ export function abilities(state: w.GameState): Record<string, w.Returns<Omit<w.P
         },
         unapply: (target: w.Targetable) => {
           if (isObject(target)) {
+            //console.log(`${aid}: unapply ${effect} to '${target.card.name}'`);
             target.effects = (target.effects || []).filter((eff) => eff.aid !== aid);
           }
         }

--- a/src/common/vocabulary/triggers.ts
+++ b/src/common/vocabulary/triggers.ts
@@ -4,6 +4,7 @@ import * as w from '../types';
 
 export function setTrigger(state: w.GameState, currentObject: w.Object | null, source: w.AbilityId | null): w.Returns<void> {
   function areTriggersEqual(t1: w.TriggeredAbility, t2: w.TriggeredAbility): boolean {
+    /* istanbul ignore next: it's no longer clear to me when this check should actually be run or what its purpose is (see longer comment below) -AN */
     return isEqual(omit(t1, ['trigger']), omit(t2, ['trigger'])) &&
       isEqual(omit(t1.trigger, ['targets']), omit(t2.trigger, ['targets']));
   }

--- a/test/components/Board.spec.js
+++ b/test/components/Board.spec.js
@@ -38,6 +38,7 @@ describe('Board component', () => {
         'type': TYPE_CORE,
         'abilities': [],
         'triggers': [],
+        'effects': [],
         'attacking': null,
         'isDamaged': false
       },
@@ -53,6 +54,7 @@ describe('Board component', () => {
         'type': TYPE_CORE,
         'abilities': [],
         'triggers': [],
+        'effects': [],
         'attacking': null,
         'isDamaged': false
       }

--- a/test/data/cards.ts
+++ b/test/data/cards.ts
@@ -232,7 +232,6 @@ export const infiniteLoopBotCard: w.CardInStore = {
     speed: 1
   }
 };
-
 export const armorerCard: w.CardInStore = {
   metadata: { source: { type: 'user' } as w.CardSource },
   id: 'Armorer',
@@ -249,6 +248,7 @@ export const armorerCard: w.CardInStore = {
     speed: 1
   }
 };
+
 
 export const countdownClockCard: w.CardInStore = {
   metadata: { source: { type: 'user' } as w.CardSource },
@@ -294,4 +294,19 @@ export const rageCard: w.CardInStore = {
   stats: {
     health: 3,
   },
+};
+
+export const librarySchoolCard: w.CardInStore = {
+  metadata: { source: { type: 'user' } as w.CardSource },
+  id: 'Library School',
+  name: 'Library School',
+  text: 'All robots have "Activate: Draw a card, then discard a random card"',
+  abilities: [
+    "(function () { setAbility(abilities['giveAbility'](function () { return objectsMatchingConditions('robot', []); }, \"(function () { setAbility(abilities['activated'](function () { return targets['thisRobot'](); }, \\\"(function () { (function () { actions['draw'](targets['self'](), 1); })(); (function () { actions['discard'](targets['random'](1, cardsInHand(targets['self'](), 'anycard', []))); })(); })\\\")); })\")); })"
+  ],
+  cost: 5,
+  type: TYPE_STRUCTURE,
+  stats: {
+    health: 3
+  }
 };

--- a/test/reducers/game.spec.ts
+++ b/test/reducers/game.spec.ts
@@ -656,6 +656,20 @@ describe('Game reducer', () => {
       // Since Blue Bot has had Armorer's ability applied twice, it should restore 2 health, thus only losing 1 health.
       expect(queryObjectAttribute(state, '1,2,-3', 'health')).toBe(cards.blueBotCard.stats!.health - 1);
     });
+
+    it('should allow activated abilities to be granted by passive abilities', () => {
+      let state = getDefaultState();
+      state = playObject(state, 'orange', cards.oneBotCard, '1,2,-3');
+      expect(allObjectsOnBoard(state)['1,2,-3'].activatedAbilities || []).toHaveLength(0);
+
+      // Library School: "All robots have "Activate: Draw a card, then discard a random card" "
+      state = playObject(state, 'orange', testCards.librarySchoolCard, '3,-1,-2');
+      expect(allObjectsOnBoard(state)['1,2,-3'].activatedAbilities || []).toHaveLength(1);
+
+      // Now let's destroy Library School with Smash. One Bot's activated ability should go away.
+      state = playEvent(state, 'blue', cards.smashCard, { hex: '3,-1,-2' });
+      expect(allObjectsOnBoard(state)['1,2,-3'].activatedAbilities || []).toHaveLength(0);
+    });
   });
 
   describe('[Shared deck mode]', () => {

--- a/test/reducers/game.spec.ts
+++ b/test/reducers/game.spec.ts
@@ -11,7 +11,7 @@ import * as cards from '../../src/common/store/cards';
 import defaultState from '../../src/common/store/defaultGameState';
 import * as w from '../../src/common/types';
 import { instantiateCard } from '../../src/common/util/cards';
-import { getCost } from '../../src/common/util/game';
+import { allObjectsOnBoard, getCost, hasEffect } from '../../src/common/util/game';
 import * as testCards from '../data/cards';
 import {
   activate, action, attack, drawCardToHand, getDefaultState, moveRobot,
@@ -22,7 +22,7 @@ import {
 describe('Game reducer', () => {
   it('should return the initial state', () => {
     const gameState = game();
-    const expectedGameState = {...cloneDeep(defaultState), actionId: gameState.actionId};
+    const expectedGameState = { ...cloneDeep(defaultState), actionId: gameState.actionId };
     expect(gameState).toEqual(expectedGameState);
   });
 
@@ -46,36 +46,36 @@ describe('Game reducer', () => {
       state = playObject(state, 'orange', testCards.attackBotCard, '3,-1,-2');
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
 
       // Can't play a robot far from core.
       state = playObject(state, 'orange', testCards.attackBotCard, '1,0,-1');
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
 
       // Can't play a robot on an existing location.
       state = playObject(state, 'orange', testCards.attackBotCard, '3,-1,-2');
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
 
       // Can play a structure adjacent to a robot ...
       state = playObject(state, 'orange', cards.fortificationCard, '2,0,-2');
       expect(
         objectsOnBoardOfType(state, TYPE_STRUCTURE)
-      ).toEqual({'2,0,-2': 'Fortification'});
+      ).toEqual({ '2,0,-2': 'Fortification' });
       // ... but not far away from a robot.
       state = playObject(state, 'orange', cards.fortificationCard, '0,0,0');
       expect(
         objectsOnBoardOfType(state, TYPE_STRUCTURE)
-      ).toEqual({'2,0,-2': 'Fortification'});
+      ).toEqual({ '2,0,-2': 'Fortification' });
 
       // Can't play a structure on an existing location.
       state = playObject(state, 'orange', cards.fortificationCard, '2,0,-2');
       expect(
         objectsOnBoardOfType(state, TYPE_STRUCTURE)
-      ).toEqual({'2,0,-2': 'Fortification'});
+      ).toEqual({ '2,0,-2': 'Fortification' });
     });
 
     it('should be able to move robots', () => {
@@ -86,7 +86,7 @@ describe('Game reducer', () => {
       state = moveRobot(state, '3,-1,-2', '1,0,-1');
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
 
       state = newTurn(state, 'orange');
 
@@ -94,23 +94,23 @@ describe('Game reducer', () => {
       state = moveRobot(state, '3,-1,-2', ORANGE_CORE_HEX); // There's a kernel there!
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
 
       // Robots can move up to their movement range (Attack Bot has range 2).
       state = moveRobot(state, '3,-1,-2', '0,-1,1'); // Try to move 3 spaces.
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'3,-1,-2': 'Attack Bot'});
+      ).toEqual({ '3,-1,-2': 'Attack Bot' });
       state = moveRobot(state, '3,-1,-2', '1,-1,0'); // Move 2 spaces.
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'1,-1,0': 'Attack Bot'});
+      ).toEqual({ '1,-1,0': 'Attack Bot' });
 
       // Robots cannot move after they've their movesMade reaches their speed.
       state = moveRobot(state, '1,-1,0', '0,0,0'); // Try to move 1 space.
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'1,-1,0': 'Attack Bot'});
+      ).toEqual({ '1,-1,0': 'Attack Bot' });
 
       state = newTurn(state, 'orange');
 
@@ -122,7 +122,7 @@ describe('Game reducer', () => {
 
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'-2,-1,3': 'Attack Bot'});
+      ).toEqual({ '-2,-1,3': 'Attack Bot' });
     });
 
     it('should be able to handle combat between robots', () => {
@@ -274,14 +274,14 @@ describe('Game reducer', () => {
       // "Deal 3 damage to a robot."
       let state = getDefaultState();
       state = playObject(state, 'orange', testCards.attackBotCard, '3,-1,-2');
-      state = playEvent(state, 'blue', cards.shockCard, {hex: '3,-1,-2'});
+      state = playEvent(state, 'blue', cards.shockCard, { hex: '3,-1,-2' });
       expect(objectsOnBoardOfType(state, TYPE_ROBOT)).toEqual({});
 
       // Test ability to select an empty tile:
       // "Deal 1 damage to everything adjacent to a tile."
       state = playObject(state, 'orange', testCards.attackBotCard, '3,-1,-2');
       state = playObject(state, 'orange', testCards.attackBotCard, '2,1,-3');
-      state = playEvent(state, 'blue', cards.firestormCard, {hex: '2,0,-2'});
+      state = playEvent(state, 'blue', cards.firestormCard, { hex: '2,0,-2' });
       expect(objectsOnBoardOfType(state, TYPE_ROBOT)).toEqual({});
       expect(queryPlayerHealth(state, 'orange')).toEqual(STARTING_PLAYER_HEALTH - 1);
 
@@ -289,7 +289,7 @@ describe('Game reducer', () => {
       // "Discard a robot card. Gain life equal to its health."
       // (This also tests the ability to store 'it' in game state for later retrieval.)
       state = drawCardToHand(state, 'blue', cards.twoBotCard);
-      state = playEvent(state, 'blue', cards.consumeCard, {card: cards.twoBotCard});
+      state = playEvent(state, 'blue', cards.consumeCard, { card: cards.twoBotCard });
       expect(
         state.players.blue.hand.length
       ).toEqual(startingHandSize);
@@ -300,10 +300,10 @@ describe('Game reducer', () => {
       let state = getDefaultState();
       state = playObject(state, 'orange', testCards.attackBotCard, '3,-1,-2');
       // "Move a robot up to two spaces."
-      state = playEvent(state, 'orange', cards.gustOfWindCard, [{hex: '3,-1,-2'}, {hex: '1,-1,0'}]);
+      state = playEvent(state, 'orange', cards.gustOfWindCard, [{ hex: '3,-1,-2' }, { hex: '1,-1,0' }]);
       expect(
         objectsOnBoardOfType(state, TYPE_ROBOT)
-      ).toEqual({'1,-1,0': 'Attack Bot'});
+      ).toEqual({ '1,-1,0': 'Attack Bot' });
     });
 
     it('should not be able to play an event if there are no valid targets', () => {
@@ -374,6 +374,25 @@ describe('Game reducer', () => {
       expect(objectsOnBoardOfType(state, TYPE_ROBOT)).not.toHaveProperty('1,-1,0');
     });
 
+    it('should unapply effects when targets no longer meet conditions', () => {
+      let state = setUpBoardState({
+        'orange': { '3,-1,-2': cards.defenderBotCard }, // Defender Bot has Taunt
+        'blue': { '1,0,-1': cards.oneBotCard }
+      });
+      state = newTurn(state, 'blue');
+
+      // Taunt doesn't currently apply to One Bot because it's not adjacent to Defender Bot
+      expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
+
+      // Move One Bot adjacent to Defender Bot – it should have the Taunt effect applied to it.
+      state = moveRobot(state, '1,0,-1', '2,0,-2');
+      expect(hasEffect(allObjectsOnBoard(state)['2,0,-2'], 'canonlyattack')).toBe(true);
+
+      // Move One Bot back away from Defender Bot – it should have the Taunt effect unapplied from it.
+      state = moveRobot(state, '2,0,-2', '1,0,-1');
+      expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
+    });
+
     it('should let objects apply passive abilities to other objects', () => {
       // General Bot: "Your adjacent robots have +1 attack. When this robot is played, all of your robots can move again."
       // Fortification: "Your adjacent robots have +1 health."
@@ -396,8 +415,8 @@ describe('Game reducer', () => {
       expect(queryRobotAttributes(state, '2,-1,-1')).toEqual('2/1/2');
 
       // Destroy General Bot to remove its passive ability.
-      state = playEvent(state, 'orange', cards.shockCard, {hex: '1,-1,0'});
-      state = playEvent(state, 'orange', cards.shockCard, {hex: '1,-1,0'});
+      state = playEvent(state, 'orange', cards.shockCard, { hex: '1,-1,0' });
+      state = playEvent(state, 'orange', cards.shockCard, { hex: '1,-1,0' });
       expect(queryRobotAttributes(state, '2,-1,-1')).toEqual('1/1/2');
 
       // Place a new Attack Bot that is adjacent to Fortification.
@@ -448,14 +467,14 @@ describe('Game reducer', () => {
       expect(costOf(state.players.orange, cards.fortificationCard)).toEqual(cards.fortificationCard.cost - 1);
 
       // Test interaction with Investor Bot ("When this robot is played, reduce the cost of a card in your hand by 2").
-      state = playObject(state, 'orange', testCards.investorBotCard, '2,1,-3', {card: cards.generalBotCard});
+      state = playObject(state, 'orange', testCards.investorBotCard, '2,1,-3', { card: cards.generalBotCard });
       expect(costOf(state.players.orange, testCards.attackBotCard)).toEqual(0);
       expect(costOf(state.players.orange, cards.monkeyBotCard)).toEqual(cards.monkeyBotCard.cost - 1 - 1);
       expect(costOf(state.players.orange, cards.generalBotCard)).toEqual(cards.generalBotCard.cost - 1 - 1 - 2);
       expect(costOf(state.players.orange, cards.fortificationCard)).toEqual(cards.fortificationCard.cost - 1);
 
       // Now destroy Recruiter Bot.
-      state = playEvent(state, 'orange', cards.shockCard, {hex: '3,-1,-2'});
+      state = playEvent(state, 'orange', cards.shockCard, { hex: '3,-1,-2' });
       expect(costOf(state.players.orange, testCards.attackBotCard)).toEqual(0);
       expect(costOf(state.players.orange, cards.monkeyBotCard)).toEqual(cards.monkeyBotCard.cost - 1);
       expect(costOf(state.players.orange, cards.generalBotCard)).toEqual(cards.generalBotCard.cost - 1 - 2);
@@ -509,7 +528,7 @@ describe('Game reducer', () => {
       expect(objectsOnBoardOfType(state, TYPE_ROBOT)).toHaveProperty('1,0,-1');
 
       // Now, destroy the Anti-Gravity Field.
-      state = playEvent(state, 'orange', cards.smashCard, {hex: '-2,-1,3'});
+      state = playEvent(state, 'orange', cards.smashCard, { hex: '-2,-1,3' });
       expect(objectsOnBoardOfType(state, TYPE_STRUCTURE)).not.toHaveProperty('-3,0,3');
 
       // Robots can no longer jump.
@@ -548,7 +567,7 @@ describe('Game reducer', () => {
       expect(handSize()).toEqual(currentHandSize + 1);
 
       // Now, destroy the Magpie Machine.
-      state = playEvent(state, 'orange', cards.smashCard, {hex: '2,0,-2'});
+      state = playEvent(state, 'orange', cards.smashCard, { hex: '2,0,-2' });
       expect(objectsOnBoardOfType(state, TYPE_STRUCTURE)).not.toHaveProperty('2,0,-2');
 
       // No card draw.
@@ -576,18 +595,18 @@ describe('Game reducer', () => {
       state = playObject(state, 'orange', cards.recyclerCard, '2,1,-3');
 
       // Can't activate the turn it's played.
-      state = activate(state, '2,1,-3', 0, {card: 0});
+      state = activate(state, '2,1,-3', 0, { card: 0 });
       expect(hand()).toEqual(currentHand);
 
       // Can activate the next turn.
       state = newTurn(state, 'orange');
       currentHand = hand();
-      state = activate(state, '2,1,-3', 0, {card: 0});
+      state = activate(state, '2,1,-3', 0, { card: 0 });
       expect(hand()).not.toEqual(currentHand);
 
       // Can't activate twice in a turn.
       currentHand = hand();
-      state = activate(state, '2,1,-3', 0, {card: 0});
+      state = activate(state, '2,1,-3', 0, { card: 0 });
       expect(hand()).toEqual(currentHand);
 
       // Can't activate then attack on the same turn.
@@ -599,7 +618,7 @@ describe('Game reducer', () => {
       state = attack(state, '2,1,-3', '1,1,-2');
       expect(queryObjectAttribute(state, '1,1,-2', 'health')).toEqual(cards.fortificationCard.stats!.health - 1);
       currentHand = hand();
-      state = activate(state, '2,1,-3', 0, {card: 0});
+      state = activate(state, '2,1,-3', 0, { card: 0 });
       expect(hand()).toEqual(currentHand);
     });
 

--- a/test/store/cards.spec.ts
+++ b/test/store/cards.spec.ts
@@ -28,6 +28,7 @@ describe('Built-in cards', () => {
       stats: { attack: 1, health: 1, speed: 1 },
       abilities: new Array<w.PassiveAbility>(),
       triggers: new Array<w.TriggeredAbility>(),
+      effects: [],
       movesMade: 0
     };
 
@@ -39,7 +40,7 @@ describe('Built-in cards', () => {
 
           // Try executing all triggers.
           dummyCurrentObj.triggers.forEach((trigger) => {
-            executeCmd({...state, that: dummyCurrentObj}, trigger.action, dummyCurrentObj);
+            executeCmd({ ...state, that: dummyCurrentObj }, trigger.action, dummyCurrentObj);
           });
 
           // And reset the dummy object.

--- a/test/vocabulary/abilities.spec.ts
+++ b/test/vocabulary/abilities.spec.ts
@@ -1,30 +1,9 @@
 import { times } from 'lodash';
 
-import { allObjectsOnBoard, hasEffect } from '../../src/common/util/game';
-import * as cards from '../../src/common/store/cards';
 import * as testCards from '../data/cards';
-import { getDefaultState, moveRobot, newTurn, playObject, setUpBoardState } from '../testHelpers';
+import { getDefaultState, newTurn, playObject } from '../testHelpers';
 
 describe('[vocabulary.abilities]', () => {
-  it('Abilities unapply when targets no longer meet conditions', () => {
-    let state = setUpBoardState({
-      'orange': { '3,-1,-2': cards.defenderBotCard }, // Defender Bot has Taunt
-      'blue': { '1,0,-1': cards.oneBotCard }
-    });
-    state = newTurn(state, 'blue');
-
-    // Taunt doesn't currently apply to One Bot because it's not adjacent to Defender Bot
-    expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
-
-    // Move One Bot adjacent to Defender Bot – it should have the Taunt effect applied to it.
-    state = moveRobot(state, '1,0,-1', '2,0,-2');
-    expect(hasEffect(allObjectsOnBoard(state)['2,0,-2'], 'canonlyattack')).toBe(true);
-
-    // Move One Bot back away from Defender Bot – it should have the Taunt effect unapplied from it.
-    state = moveRobot(state, '2,0,-2', '1,0,-1');
-    expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
-  });
-
   it('conditionalAction', () => {
     let state = getDefaultState();
     // Countdown Clock:

--- a/test/vocabulary/abilities.spec.ts
+++ b/test/vocabulary/abilities.spec.ts
@@ -1,9 +1,30 @@
 import { times } from 'lodash';
 
+import { allObjectsOnBoard, hasEffect } from '../../src/common/util/game';
+import * as cards from '../../src/common/store/cards';
 import * as testCards from '../data/cards';
-import { getDefaultState, newTurn, playObject } from '../testHelpers';
+import { getDefaultState, moveRobot, newTurn, playObject, setUpBoardState } from '../testHelpers';
 
 describe('[vocabulary.abilities]', () => {
+  it('Abilities unapply when targets no longer meet conditions', () => {
+    let state = setUpBoardState({
+      'orange': { '3,-1,-2': cards.defenderBotCard }, // Defender Bot has Taunt
+      'blue': { '1,0,-1': cards.oneBotCard }
+    });
+    state = newTurn(state, 'blue');
+
+    // Taunt doesn't currently apply to One Bot because it's not adjacent to Defender Bot
+    expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
+
+    // Move One Bot adjacent to Defender Bot – it should have the Taunt effect applied to it.
+    state = moveRobot(state, '1,0,-1', '2,0,-2');
+    expect(hasEffect(allObjectsOnBoard(state)['2,0,-2'], 'canonlyattack')).toBe(true);
+
+    // Move One Bot back away from Defender Bot – it should have the Taunt effect unapplied from it.
+    state = moveRobot(state, '2,0,-2', '1,0,-1');
+    expect(hasEffect(allObjectsOnBoard(state)['1,0,-1'], 'canonlyattack')).toBe(false);
+  });
+
   it('conditionalAction', () => {
     let state = getDefaultState();
     // Countdown Clock:


### PR DESCRIPTION
– Robot effects have visual cues on the board (for all Effects, as well as a hacky implementation for Taunt that only looks at card text): #376
– Fixed issues with abilities not getting applied/unapplied correctly sometimes (and added some tests): #1628, #1632
– Performance boost from re-executing abilities only when targets have changed: #1633
– In-game UX fixes: #1629, #1631