### PR TITLE
New vocabulary: triggers['afterDealsDamage'] and actions['canActivateAgain']

### DIFF
--- a/src/common/containers/About.tsx
+++ b/src/common/containers/About.tsx
@@ -16,7 +16,7 @@ interface AboutProps {
 }
 
 interface AboutState {
-  parserVersion: string
+  parserVersion?: { version: string, sha: string }
 }
 
 export function mapStateToProps(state: w.State): AboutProps {
@@ -26,8 +26,8 @@ export function mapStateToProps(state: w.State): AboutProps {
 }
 
 class About extends React.PureComponent<AboutProps, AboutState> {
-  public state = {
-    parserVersion: '(loading)'
+  public state: AboutState = {
+    parserVersion: undefined
   };
 
   public componentWillMount() {
@@ -74,7 +74,8 @@ class About extends React.PureComponent<AboutProps, AboutState> {
               <pre>
                 Game version: v<a href={`https://github.com/wordbots/wordbots-core/releases/tag/v${version}`}>{version}</a><br />
                 Build SHA: {shaTruncated === 'local' ? '(local)' : <a href={`https://github.com/wordbots/wordbots-core/commit/${sha}`}>{shaTruncated}</a>}<br />
-                Parser version: {parserVersion.startsWith('(') ? parserVersion : <a href={`https://github.com/wordbots/wordbots-parser/releases/tag/${parserVersion}`}>{parserVersion}</a>}
+                Parser version: {parserVersion ? <a href={`https://github.com/wordbots/wordbots-parser/releases/tag/${parserVersion.version}`}>{parserVersion.version}</a> : '(loading)'}<br />
+                Parser SHA: {parserVersion ? parserVersion.sha === 'local' ? '(local)' : <a href={`https://github.com/wordbots/wordbots-parser/commit/${parserVersion.sha}`}>{truncate(parserVersion.sha, { length: 8, omission: '' })}</a> : '(loading)'}
               </pre>
             </Paper>
           </div>
@@ -102,9 +103,7 @@ class About extends React.PureComponent<AboutProps, AboutState> {
         parserVersion: await lookupParserVersion()
       });
     } catch (error) {
-      this.setState({
-        parserVersion: '(failed to connect to parser)'
-      });
+      console.error(error);
     }
   }
 }

--- a/src/common/containers/Admin.tsx
+++ b/src/common/containers/Admin.tsx
@@ -35,7 +35,7 @@ interface AdminState {
   migrationPreviewReport: PreviewReport | null
   cardsBeingMigrated: w.CardInStore[]
   setBeingMigrated: w.SetId | null
-  parserVersion?: string
+  parserVersion?: { version: string, sha: string }
   isPreviewingMigration?: boolean
 }
 
@@ -69,7 +69,7 @@ class Admin extends React.PureComponent<AdminProps> {
 
   private renderPanelForCards(cards: w.CardInStore[], setId: w.SetId | null, builtIn?: boolean) {
     const { parserVersion, isPreviewingMigration } = this.state;
-    const outOfDateCards = parserVersion ? cards.filter(c => c.metadata.source.type !== 'builtin' && c.parserV !== parserVersion) : undefined;
+    const outOfDateCards = parserVersion ? cards.filter(c => c.metadata.source.type !== 'builtin' && c.parserV !== parserVersion!.version) : undefined;
     const onClickPreview = () => { this.previewMigration(cards, setId); };
 
     return (
@@ -116,7 +116,8 @@ class Admin extends React.PureComponent<AdminProps> {
           <div><b>Parser URL:</b> {PARSER_URL}</div>
           <div><b>Firebase URL:</b> {FIREBASE_CONFIG.databaseURL}</div>
           <div><b>Game Version:</b> {version}</div>
-          <div><b>Parser Version:</b> {parserVersion}</div>
+          <div><b>Parser Version:</b> {parserVersion?.version}</div>
+          <div><b>Parser SHA:</b> {parserVersion?.sha}</div>
         </Paper>
         <Paper style={{ margin: 20, padding: 10 }}>
           <h2>All player-made cards</h2>
@@ -294,7 +295,7 @@ class Admin extends React.PureComponent<AdminProps> {
       const migratedCard: w.CardInStore = {
         ...omit(card, ['parseErrors', 'oldAbilities', 'newAbilities']),
         ...(card.type === TYPE_EVENT ? { command: card.newAbilities } : { abilities: card.newAbilities }),
-        parserV: parserVersion!,
+        parserV: parserVersion!.version,
         originalParserV,
         migrationBackup: [
           ...(card.migrationBackup || []),
@@ -321,7 +322,7 @@ class Admin extends React.PureComponent<AdminProps> {
 
     const migratedCard: w.CardInStore = {
       ...card,
-      parserV: parserVersion!,
+      parserV: parserVersion!.version,
       originalParserV: card.parserV || 'unknown'
     };
 

--- a/src/common/util/cards.ts
+++ b/src/common/util/cards.ts
@@ -303,10 +303,9 @@ export function parseCard(
   );
 }
 
-export async function lookupParserVersion(): Promise<string> {
-  const parserResponse = await fetch(`${PARSER_URL}/parse?format=js&input=Draw%20a%20card`);
-  const parserResponseJson = await parserResponse.json();
-  return parserResponseJson.version;
+export async function lookupParserVersion(): Promise<{ version: string, sha: string }> {
+  const parserResponse = await fetch(`${PARSER_URL}/version`);
+  return await parserResponse.json();
 }
 
 //

--- a/src/common/vocabulary/actions.ts
+++ b/src/common/vocabulary/actions.ts
@@ -90,6 +90,12 @@ export default function actions(state: w.GameState, currentObject: w.Object | nu
       }
     },
 
+    canActivateAgain: (objects: w.ObjectOrPlayerCollection): void => {
+      iterateOver<w.Object>(objects)((object: w.Object) => {
+        Object.assign(object, { cantActivate: false });
+      });
+    },
+
     canAttackAgain: (objects: w.ObjectOrPlayerCollection): void => {
       iterateOver<w.Object>(objects)((object: w.Object) => {
         Object.assign(object, { cantAttack: false });

--- a/src/common/vocabulary/triggers.ts
+++ b/src/common/vocabulary/triggers.ts
@@ -76,6 +76,12 @@ export function triggers(_state: w.GameState): Record<string, w.Returns<w.Trigge
       targetFunc: `(${targetFunc.toString()})`
     }),
 
+    afterDealsDamage: (targetFunc: (state: w.GameState) => w.Target[], objectType: w.CardTypeQuery | w.CardTypeQuery[]): w.Trigger => ({
+      type: 'afterDealsDamage',
+      cardType: objectType,
+      targetFunc: `(${targetFunc.toString()})`
+    }),
+
     afterDestroyed: (targetFunc: (state: w.GameState) => w.Target[], cause: w.Cause): w.Trigger => ({
       type: 'afterDestroyed',
       cause,

--- a/test/vocabulary/actions.spec.ts
+++ b/test/vocabulary/actions.spec.ts
@@ -6,10 +6,22 @@ import { allObjectsOnBoard } from '../../src/common/util/game';
 import * as testCards from '../data/cards';
 import {
   attack, action, getDefaultState, objectsOnBoardOfType,
-  playEvent, playObject, queryPlayerHealth, queryRobotAttributes, setUpBoardState, startingHandSize
+  playEvent, playObject, queryPlayerHealth, queryRobotAttributes, setUpBoardState, startingHandSize, activate
 } from '../testHelpers';
 
 describe('[vocabulary.actions]', () => {
+  it('canActivateAgain', () => {
+    let state = setUpBoardState({
+      orange: { '0,0,0': cards.governmentResearcherCard },  // Activate: Pay 1 energy and each player draws a card.
+    });
+
+    state = activate(state, '0,0,0', 0);
+    expect(state.players.orange.hand.length).toEqual(2);
+    state = playEvent(state, 'orange', action("All robots can activate.", "(function () { actions['canActivateAgain'](objectsMatchingConditions('robot', [])); })"));
+    state = activate(state, '0,0,0', 0);
+    expect(state.players.orange.hand.length).toEqual(3);
+  });
+
   it('canAttackAgain', () => {
     let state = setUpBoardState({
       orange: { '0,0,0': cards.twoBotCard },


### PR DESCRIPTION
close #1833, close #1834, close #1835