### PR TITLE
Don't grey out structures on cards anymore

### DIFF
--- a/src/common/components/card/CardImage.tsx
+++ b/src/common/components/card/CardImage.tsx
@@ -107,7 +107,7 @@ export default class CardImage extends React.Component<CardImageProps, CardImage
         >
           <Sprite
             id={spriteID}
-            palette={type === TYPE_ROBOT ? 'nes' : 'greys'}
+            palette="nes"
             size={24}
             scale={scale}
             output="html"

--- a/src/common/components/card/CardImage.tsx
+++ b/src/common/components/card/CardImage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { TYPE_CORE, TYPE_EVENT, TYPE_ROBOT } from '../../constants';
+import { TYPE_CORE, TYPE_EVENT } from '../../constants';
 import * as w from '../../types';
 import loadImages from '../hexgrid/HexGridImages';
 import Sprite from '../Sprite';

--- a/src/common/components/hexgrid/PiecePattern.tsx
+++ b/src/common/components/hexgrid/PiecePattern.tsx
@@ -16,11 +16,11 @@ export default class PiecePattern extends React.Component<PiecePatternProps> {
   }
 
   get imageElt(): JSX.Element | undefined {
-    const { image, type } = this.props.piece;
+    const { image } = this.props.piece;
 
     if (image) {
       if (isSpriteImage(image)) {
-        return <Sprite id={image.sprite} size={24} spacing={6} output="svg" palette={type === TYPE_STRUCTURE ? 'greys' : 'nes'} />;
+        return <Sprite id={image.sprite} size={24} spacing={6} output="svg" palette="nes" />;
       } else if (image.img && this.images[image.img]) {
         // (only kernels have static images)
         return <image xlinkHref={this.images[image.img]} width="0.6" height="0.6" x="0.2" y="0.25" style={{ imageRendering: 'pixelated' }} />;

--- a/src/common/components/hexgrid/PiecePattern.tsx
+++ b/src/common/components/hexgrid/PiecePattern.tsx
@@ -16,11 +16,11 @@ export default class PiecePattern extends React.Component<PiecePatternProps> {
   }
 
   get imageElt(): JSX.Element | undefined {
-    const { image } = this.props.piece;
+    const { image, type } = this.props.piece;
 
     if (image) {
       if (isSpriteImage(image)) {
-        return <Sprite id={image.sprite} size={24} spacing={6} output="svg" palette="nes" />;
+        return <Sprite id={image.sprite} size={24} spacing={6} output="svg" palette={type === TYPE_STRUCTURE ? 'greys' : 'nes'} />;
       } else if (image.img && this.images[image.img]) {
         // (only kernels have static images)
         return <image xlinkHref={this.images[image.img]} width="0.6" height="0.6" x="0.2" y="0.25" style={{ imageRendering: 'pixelated' }} />;


### PR DESCRIPTION
Since we no longer grey out structures on the board (see #1051), it makes sense to not grey them out in cards either, for consistency.